### PR TITLE
Fix template_ws

### DIFF
--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -7,6 +7,7 @@ FROM arm64v8/ros:humble AS arm64
 # It may be `arm64` or `amd64` depending on the platform.
 # Ref: https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
 FROM $TARGETARCH
+ARG TARGETARCH
 
 # Arguments for the default user
 ARG USERNAME=user


### PR DESCRIPTION
I’m very sorry that I didn’t notice this serious error during yesterday’s review. I forgot to include the `TARGETARCH` parameter in the Dockerfile, which caused issues like missing Gazebo installations and other significant problems when using this variable later on.