### PR TITLE
Fix `clearpath_generator_robot` NotImplementedError

### DIFF
--- a/husky_ws/docker/script/install-clearpath-robot.sh
+++ b/husky_ws/docker/script/install-clearpath-robot.sh
@@ -14,7 +14,7 @@ cd ~/husky_driver_ws/src
 #
 #     E: Unable to locate package ros-humble-clearpath-robot
 #
-git clone https://github.com/clearpathrobotics/clearpath_robot -b 0.2.11
+git clone https://github.com/clearpathrobotics/clearpath_robot -b 0.3.2
 cd ..
 
 # Remove unnecessary dependencies (`micros_ros_agent`, `sevcon_traction`, `umx_driver`, `valence_bms_driver`)


### PR DESCRIPTION
Error message:

     > [husky-ws stage-2 21/21] RUN bash -ie /home/user/script/husky-generate.sh:
       bash: cannot set terminal process group (1): Inappropriate ioctl for device
       bash: no job control in this shell
       Workspace has not been built yet. Building workspace...
       Starting >>> clearpath_diagnostics
       Starting >>> clearpath_sensors
       Finished <<< clearpath_sensors [0.09s]
       Finished <<< clearpath_diagnostics [0.39s]
       Starting >>> clearpath_generator_robot
       Finished <<< clearpath_generator_robot [0.43s]
       Starting >>> clearpath_robot
       Finished <<< clearpath_robot [0.08s]

       Summary: 4 packages finished [1.14s]
       Workspace built.
       Successfully built workspace and configured environment variables.
       bash: /etc/clearpath/setup.bash: No such file or directory
       bash: /install/setup.bash: No such file or directory
       Generated /etc/clearpath/robot.urdf.xacro
       Generated config: /etc/clearpath/platform/config/control.yaml
       Generated config: /etc/clearpath/platform/config/imu_filter.yaml
       Generated config: /etc/clearpath/platform/config/localization.yaml
       Generated config: /etc/clearpath/platform/config/teleop_interactive_markers.yaml
       Generated config: /etc/clearpath/platform/config/teleop_joy.yaml
       Generated config: /etc/clearpath/platform/config/twist_mux.yaml
       Generated config: /etc/clearpath/manipulators/config/moveit.yaml
       Generated config: /etc/clearpath/manipulators/config/control.yaml
       Traceback (most recent call last):
         File "/home/user/husky_driver_ws/install/clearpath_generator_robot/lib/clearpath_generator_robot/generate_launch", line 46, in <module>
           main()
         File "/home/user/husky_driver_ws/install/clearpath_generator_robot/lib/clearpath_generator_robot/generate_launch", line 42, in main
           rlg.generate()
         File "/opt/ros/humble/local/lib/python3.10/dist-packages/clearpath_generator_common/launch/generator.py", line 100, in generate
           self.generate_manipulators()
         File "/opt/ros/humble/local/lib/python3.10/dist-packages/clearpath_generator_common/launch/generator.py", line 112, in generate_manipulators
           raise NotImplementedError()
       NotImplementedError
       [ros2run]: Process exited with failure 1
    ------
    failed to solve: process "/bin/sh -c bash -ie /home/$USERNAME/script/husky-generate.sh" did not complete successfully: exit code: 1