### PR TITLE
Add Docker Modules and Update Isaac Sim & Lab

### DIFF
--- a/.github/workflows/build-aloha-ws.yaml
+++ b/.github/workflows/build-aloha-ws.yaml
@@ -34,6 +34,7 @@ jobs:
         ref: ${{ env.CURRENT_BRANCH }}
         filters: |
           results:
+            - docker_modules/**
             - .github/workflows/build-aloha-ws.yaml
             - aloha_ws/docker/Dockerfile
             - aloha_ws/docker/.dockerignore
@@ -64,6 +65,8 @@ jobs:
         run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run post install script
+        run: scripts/post_install.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/build-cartographer-ws.yaml
+++ b/.github/workflows/build-cartographer-ws.yaml
@@ -34,6 +34,7 @@ jobs:
         ref: ${{ env.CURRENT_BRANCH }}
         filters: |
           results:
+            - docker_modules/**
             - .github/workflows/build-cartographer-ws.yaml
             - cartographer_ws/docker/Dockerfile
             - cartographer_ws/docker/.dockerignore
@@ -62,6 +63,8 @@ jobs:
         run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run post install script
+        run: scripts/post_install.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/build-delto-gripper-ws.yaml
+++ b/.github/workflows/build-delto-gripper-ws.yaml
@@ -34,6 +34,7 @@ jobs:
         ref: ${{ env.CURRENT_BRANCH }}
         filters: |
           results:
+            - docker_modules/**
             - .github/workflows/build-delto-gripper-ws.yaml
             - delto_gripper_ws/docker/Dockerfile
             - delto_gripper_ws/docker/.dockerignore
@@ -62,6 +63,8 @@ jobs:
         run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run post install script
+        run: scripts/post_install.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/build-gazebo-world-ws.yaml
+++ b/.github/workflows/build-gazebo-world-ws.yaml
@@ -34,6 +34,7 @@ jobs:
         ref: ${{ env.CURRENT_BRANCH }}
         filters: |
           results:
+            - docker_modules/**
             - .github/workflows/build-gazebo-world-ws.yaml
             - gazebo_world_ws/docker/Dockerfile
             - gazebo_world_ws/docker/.dockerignore
@@ -62,6 +63,8 @@ jobs:
         run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run post install script
+        run: scripts/post_install.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/build-husky-ws.yaml
+++ b/.github/workflows/build-husky-ws.yaml
@@ -34,6 +34,7 @@ jobs:
         ref: ${{ env.CURRENT_BRANCH }}
         filters: |
           results:
+            - docker_modules/**
             - .github/workflows/build-husky-ws.yaml
             - husky_ws/docker/Dockerfile
             - husky_ws/docker/.dockerignore
@@ -65,6 +66,8 @@ jobs:
         run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run post install script
+        run: scripts/post_install.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/build-kobuki-ws.yaml
+++ b/.github/workflows/build-kobuki-ws.yaml
@@ -34,6 +34,7 @@ jobs:
         ref: ${{ env.CURRENT_BRANCH }}
         filters: |
           results:
+            - docker_modules/**
             - .github/workflows/build-kobuki-ws.yaml
             - kobuki_ws/docker/Dockerfile
             - kobuki_ws/docker/.dockerignore
@@ -64,6 +65,8 @@ jobs:
         run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run post install script
+        run: scripts/post_install.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/build-orbslam3-ws.yaml
+++ b/.github/workflows/build-orbslam3-ws.yaml
@@ -34,6 +34,7 @@ jobs:
         ref: ${{ env.CURRENT_BRANCH }}
         filters: |
           results:
+            - docker_modules/**
           - .github/workflows/build-orbslam3-ws.yaml
           - orbslam3_ws/docker/Dockerfile
           - orbslam3_ws/docker/.dockerignore
@@ -62,6 +63,8 @@ jobs:
         run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run post install script
+        run: scripts/post_install.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/build-rtabmap-ws.yaml
+++ b/.github/workflows/build-rtabmap-ws.yaml
@@ -34,6 +34,7 @@ jobs:
         ref: ${{ env.CURRENT_BRANCH }}
         filters: |
           results:
+            - docker_modules/**
           - .github/workflows/build-rtabmap-ws.yaml
           - rtabmap_ws/docker/Dockerfile
           - rtabmap_ws/docker/.dockerignore
@@ -62,6 +63,8 @@ jobs:
         run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run post install script
+        run: scripts/post_install.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/build-template-ws.yaml
+++ b/.github/workflows/build-template-ws.yaml
@@ -21,6 +21,7 @@ jobs:
       with:
         filters: |
           results:
+            - docker_modules/**
             - .github/workflows/build-template-ws.yaml
             - template_ws/docker/Dockerfile
             - template_ws/docker/.dockerignore
@@ -64,6 +65,8 @@ jobs:
         run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run post install script
+        run: scripts/post_install.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/build-turtlebot3-ws.yaml
+++ b/.github/workflows/build-turtlebot3-ws.yaml
@@ -34,6 +34,7 @@ jobs:
         ref: ${{ env.CURRENT_BRANCH }}
         filters: |
           results:
+            - docker_modules/**
             - .github/workflows/build-turtlebot3-ws.yaml
             - turtlebot3_ws/docker/Dockerfile
             - turtlebot3_ws/docker/.dockerignore
@@ -62,6 +63,8 @@ jobs:
         run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run post install script
+        run: scripts/post_install.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/build-vlp-ws.yaml
+++ b/.github/workflows/build-vlp-ws.yaml
@@ -34,6 +34,7 @@ jobs:
         ref: ${{ env.CURRENT_BRANCH }}
         filters: |
           results:
+            - docker_modules/**
             - .github/workflows/build-vlp-ws.yaml
             - vlp_ws/docker/Dockerfile
             - vlp_ws/docker/.dockerignore
@@ -62,6 +63,8 @@ jobs:
         run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run post install script
+        run: scripts/post_install.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ docker buildx rm -f --all-inactive
 
 The GitHub Actions workflow is designed to share build caches between workspaces efficiently. The template workspace is built first, and its cache is then reused by other workspaces. This means that while the template workspace build appears in the commit history, other workspace builds are triggered indirectly and only show up in the GitHub Actions tab. For implementation details, see [commit `024f52a`](https://github.com/j3soon/ros2-essentials/commit/024f52a2bb8a58ad20c03a067560215e8cef6307).
 
+Some current CI builds are flaky and may require re-running.
+
+### Docker Compose Cleanup
+
+```sh
+# cd into a workspace directory's docker directory
+docker compose down --volumes --remove-orphans
+```
+
 ## Acknowledgement
 
 The code is mainly contributed by [Johnson](https://github.com/j3soon), [Yu-Zhong Chen](https://github.com/YuZhong-Chen), [Assume Zhan](https://github.com/Assume-Zhan), [Lam Chon Hang](https://github.com/ClassLongJoe1112), and others. For a full list of contributors, please refer to the [contribution list](https://github.com/j3soon/ros2-essentials/graphs/contributors).

--- a/README.md
+++ b/README.md
@@ -72,13 +72,17 @@ mkdocs serve
 scripts/setup_docs_link.sh
 ```
 
+This is automatically done by running `./scripts/post_install.sh`.
+
 ## VSCode Intellisense
 
-If you have installed Isaac Sim 4.2.0 from [Omniverse Launcher](https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_workstation.html) to the default path `~/.local/share/ov/pkg/isaac-sim-4.2.0`, you can simply enable IntelliSense for editing any Isaac Sim scripts by running the following script:
+If you have installed [Isaac Sim 4.5.0](https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/install_workstation.html) to the default path `~/isaacsim`, you can simply enable IntelliSense for editing any Isaac Sim scripts by running the following script:
 
 ```sh
 scripts/setup_isaac_link.sh
 ```
+
+This is automatically done by running `./scripts/post_install.sh`.
 
 ## Reusing Docker Build Cache
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The documentation is hosted on <https://j3soon.github.io/ros2-essentials/>.
 ```sh
 git clone https://github.com/j3soon/ros2-essentials.git
 cd ros2-essentials
+./scripts/post_install.sh
 ```
 
 ## Pre-built Workspaces

--- a/aloha_ws/.gitignore
+++ b/aloha_ws/.gitignore
@@ -8,6 +8,7 @@
 
 # Soft Links
 /docs
+/docker/modules
 
 # Custom ignores
 /isaacsim/assets

--- a/aloha_ws/docker/.bashrc
+++ b/aloha_ws/docker/.bashrc
@@ -7,6 +7,23 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
+echo "changing ownership of Isaac Sim user cache directories..."
+sudo chown user:user /isaac-sim
+sudo chown user:user /isaac-sim/kit
+sudo chown user:user /isaac-sim/kit/cache
+sudo chown user:user /home/user/.cache
+sudo chown user:user /home/user/.cache/ov
+sudo chown user:user /home/user/.cache/pip
+sudo chown user:user /home/user/.cache/nvidia
+sudo chown user:user /home/user/.cache/nvidia/GLCache
+sudo chown user:user /home/user/.nv
+sudo chown user:user /home/user/.nv/ComputeCache
+sudo chown user:user /home/user/.nvidia-omniverse
+sudo chown user:user /home/user/.nvidia-omniverse/logs
+sudo chown user:user /home/user/.local/share/ov
+sudo chown user:user /home/user/.local/share/ov/data
+sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/aloha_ws/docker/.dockerignore
+++ b/aloha_ws/docker/.dockerignore
@@ -1,4 +1,5 @@
 *
 !.bashrc
+!modules
 !script
 !udev_rules

--- a/aloha_ws/docker/Dockerfile
+++ b/aloha_ws/docker/Dockerfile
@@ -88,7 +88,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.5.0.0
+ARG ISAAC_SIM_VERSION=4.5.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/aloha_ws/docker/Dockerfile
+++ b/aloha_ws/docker/Dockerfile
@@ -88,7 +88,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.2.0.2
+ARG ISAAC_SIM_VERSION=4.5.0.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/aloha_ws/docker/Dockerfile
+++ b/aloha_ws/docker/Dockerfile
@@ -45,71 +45,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GUI debugging tools
-# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
-#   Ref: https://packages.debian.org/sid/x11-apps
-#   Ref: https://packages.debian.org/sid/x11-utils
-# - `mesa-utils` for `glxgears` and `glxinfo`
-#   Ref: https://wiki.debian.org/Mesa
-# - `vulkan-tools` for `vkcube` and `vulkaninfo`
-#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
-#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get update && apt-get install -y \
-    x11-apps x11-utils \
-    mesa-utils \
-    libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Install Vulkan config files
-# Ref: https://gitlab.com/nvidia/container-images/vulkan
-# Ref: https://github.com/j3soon/docker-vulkan-runtime
-RUN cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194"
-    }
-}
-EOF
-RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
-    cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libEGL_nvidia.so.0"
-    }
-}
-EOF
-RUN cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "layer": {
-        "name": "VK_LAYER_NV_optimus",
-        "type": "INSTANCE",
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194",
-        "implementation_version" : "1",
-        "description" : "NVIDIA Optimus layer",
-        "functions": {
-            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
-            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
-        },
-        "enable_environment": {
-            "__NV_PRIME_RENDER_OFFLOAD": "1"
-        },
-        "disable_environment": {
-            "DISABLE_LAYER_NV_OPTIMUS_1": ""
-        }
-    }
-}
-EOF
+# Install GUI debugging tools and configure Vulkan
+COPY --chown=root:root modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
 # Install ROS2 Gazebo packages for amd64
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -143,44 +87,14 @@ USER $USERNAME
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
-# Install `libxrandr2` to support Isaac Sim WebRTC streaming
+# Isaac Sim version configuration
+ARG ISAAC_SIM_VERSION=4.2.0.2
+# Copy and run Isaac Sim installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo apt-get update && sudo apt-get install -y \
-        libxrandr2 \
-        && sudo rm -rf /var/lib/apt/lists/*; \
-    fi
-# Install Isaac Sim (requires Python 3.10)
-# Note that installing Isaac Sim with pip is experimental, keep this in mind when unexpected error occurs
-# TODO: Remove the note above when it is no longer experimental
-# Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
-RUN --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        python3 -V | grep "Python 3.10" \
-        && pip install isaacsim==4.2.0.2 --extra-index-url https://pypi.nvidia.com \
-        && pip install isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com; \
-    fi
-
-# Fix SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) `numpy==1.26.0`, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        pip install scipy==1.14.1 numpy==1.26.0; \
-    fi
-
-# Create isaac sim cache directory with correct ownership to avoid permission issues after volume mount, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo mkdir -p /isaac-sim/kit/cache \
-        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache; \
-    fi
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        mkdir -p /home/$USERNAME/.cache/ov \
-        && mkdir -p /home/$USERNAME/.cache/pip \
-        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-        && mkdir -p /home/$USERNAME/.local/share/ov/data \
-        && mkdir -p /home/$USERNAME/Documents; \
-    fi
-
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53

--- a/aloha_ws/docker/Dockerfile
+++ b/aloha_ws/docker/Dockerfile
@@ -102,6 +102,17 @@ ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
 
+# Set TERM to prevent Isaac Lab error during docker build:
+#    'ansi+tabs': unknown terminal type.
+ENV TERM=xterm-256color
+# Isaac Lab version configuration
+ARG ISAAC_LAB_VERSION=2.1.0
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     sudo apt-get update && sudo apt-get install -y \

--- a/aloha_ws/docker/compose.yaml
+++ b/aloha_ws/docker/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
       cache_from:
         - j3soon/ros2-aloha-ws:buildcache-amd64
         - j3soon/ros2-aloha-ws:buildcache-arm64

--- a/aloha_ws/docker/compose.yaml
+++ b/aloha_ws/docker/compose.yaml
@@ -21,6 +21,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
       cache_from:
         - j3soon/ros2-aloha-ws:buildcache-amd64
         - j3soon/ros2-aloha-ws:buildcache-arm64

--- a/aloha_ws/docker/compose.yaml
+++ b/aloha_ws/docker/compose.yaml
@@ -23,7 +23,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
       cache_from:
         - j3soon/ros2-aloha-ws:buildcache-amd64
         - j3soon/ros2-aloha-ws:buildcache-arm64

--- a/aloha_ws/docker/compose.yaml
+++ b/aloha_ws/docker/compose.yaml
@@ -23,6 +23,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
       cache_from:
         - j3soon/ros2-aloha-ws:buildcache-amd64
         - j3soon/ros2-aloha-ws:buildcache-arm64

--- a/aloha_ws/docker/compose.yaml
+++ b/aloha_ws/docker/compose.yaml
@@ -7,8 +7,7 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        mkdir -p /isaac-sim/standalone/{logs,data}"
     volumes:
       - isaac-sim-cache:/isaac-sim
   aloha-ws:

--- a/cartographer_ws/.gitignore
+++ b/cartographer_ws/.gitignore
@@ -8,3 +8,4 @@
 
 # Soft Links
 /docs
+/docker/modules

--- a/cartographer_ws/docker/.bashrc
+++ b/cartographer_ws/docker/.bashrc
@@ -7,6 +7,23 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
+echo "changing ownership of Isaac Sim user cache directories..."
+sudo chown user:user /isaac-sim
+sudo chown user:user /isaac-sim/kit
+sudo chown user:user /isaac-sim/kit/cache
+sudo chown user:user /home/user/.cache
+sudo chown user:user /home/user/.cache/ov
+sudo chown user:user /home/user/.cache/pip
+sudo chown user:user /home/user/.cache/nvidia
+sudo chown user:user /home/user/.cache/nvidia/GLCache
+sudo chown user:user /home/user/.nv
+sudo chown user:user /home/user/.nv/ComputeCache
+sudo chown user:user /home/user/.nvidia-omniverse
+sudo chown user:user /home/user/.nvidia-omniverse/logs
+sudo chown user:user /home/user/.local/share/ov
+sudo chown user:user /home/user/.local/share/ov/data
+sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/cartographer_ws/docker/.dockerignore
+++ b/cartographer_ws/docker/.dockerignore
@@ -1,2 +1,3 @@
 *
 !.bashrc
+!modules

--- a/cartographer_ws/docker/Dockerfile
+++ b/cartographer_ws/docker/Dockerfile
@@ -47,71 +47,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GUI debugging tools
-# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
-#   Ref: https://packages.debian.org/sid/x11-apps
-#   Ref: https://packages.debian.org/sid/x11-utils
-# - `mesa-utils` for `glxgears` and `glxinfo`
-#   Ref: https://wiki.debian.org/Mesa
-# - `vulkan-tools` for `vkcube` and `vulkaninfo`
-#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
-#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get update && apt-get install -y \
-    x11-apps x11-utils \
-    mesa-utils \
-    libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Install Vulkan config files
-# Ref: https://gitlab.com/nvidia/container-images/vulkan
-# Ref: https://github.com/j3soon/docker-vulkan-runtime
-RUN cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194"
-    }
-}
-EOF
-RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
-    cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libEGL_nvidia.so.0"
-    }
-}
-EOF
-RUN cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "layer": {
-        "name": "VK_LAYER_NV_optimus",
-        "type": "INSTANCE",
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194",
-        "implementation_version" : "1",
-        "description" : "NVIDIA Optimus layer",
-        "functions": {
-            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
-            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
-        },
-        "enable_environment": {
-            "__NV_PRIME_RENDER_OFFLOAD": "1"
-        },
-        "disable_environment": {
-            "DISABLE_LAYER_NV_OPTIMUS_1": ""
-        }
-    }
-}
-EOF
+# Install GUI debugging tools and configure Vulkan
+COPY --chown=root:root modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
 # Install ROS2 Gazebo packages for amd64
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -145,44 +89,14 @@ USER $USERNAME
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
-# Install `libxrandr2` to support Isaac Sim WebRTC streaming
+# Isaac Sim version configuration
+ARG ISAAC_SIM_VERSION=4.2.0.2
+# Copy and run Isaac Sim installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo apt-get update && sudo apt-get install -y \
-        libxrandr2 \
-        && sudo rm -rf /var/lib/apt/lists/*; \
-    fi
-# Install Isaac Sim (requires Python 3.10)
-# Note that installing Isaac Sim with pip is experimental, keep this in mind when unexpected error occurs
-# TODO: Remove the note above when it is no longer experimental
-# Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
-RUN --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        python3 -V | grep "Python 3.10" \
-        && pip install isaacsim==4.2.0.2 --extra-index-url https://pypi.nvidia.com \
-        && pip install isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com; \
-    fi
-
-# Fix SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) `numpy==1.26.0`, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        pip install scipy==1.14.1 numpy==1.26.0; \
-    fi
-
-# Create isaac sim cache directory with correct ownership to avoid permission issues after volume mount, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo mkdir -p /isaac-sim/kit/cache \
-        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache; \
-    fi
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        mkdir -p /home/$USERNAME/.cache/ov \
-        && mkdir -p /home/$USERNAME/.cache/pip \
-        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-        && mkdir -p /home/$USERNAME/.local/share/ov/data \
-        && mkdir -p /home/$USERNAME/Documents; \
-    fi
-
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53

--- a/cartographer_ws/docker/Dockerfile
+++ b/cartographer_ws/docker/Dockerfile
@@ -90,7 +90,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.5.0.0
+ARG ISAAC_SIM_VERSION=4.5.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/cartographer_ws/docker/Dockerfile
+++ b/cartographer_ws/docker/Dockerfile
@@ -90,7 +90,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.2.0.2
+ARG ISAAC_SIM_VERSION=4.5.0.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/cartographer_ws/docker/Dockerfile
+++ b/cartographer_ws/docker/Dockerfile
@@ -104,6 +104,17 @@ ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
 
+# Set TERM to prevent Isaac Lab error during docker build:
+#    'ansi+tabs': unknown terminal type.
+ENV TERM=xterm-256color
+# Isaac Lab version configuration
+ARG ISAAC_LAB_VERSION=2.1.0
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     sudo apt-get update && sudo apt-get install -y \

--- a/cartographer_ws/docker/compose.yaml
+++ b/cartographer_ws/docker/compose.yaml
@@ -23,6 +23,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
       cache_from:
         - j3soon/ros2-cartographer-ws:buildcache-amd64
         - j3soon/ros2-cartographer-ws:buildcache-arm64

--- a/cartographer_ws/docker/compose.yaml
+++ b/cartographer_ws/docker/compose.yaml
@@ -21,6 +21,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
       cache_from:
         - j3soon/ros2-cartographer-ws:buildcache-amd64
         - j3soon/ros2-cartographer-ws:buildcache-arm64

--- a/cartographer_ws/docker/compose.yaml
+++ b/cartographer_ws/docker/compose.yaml
@@ -7,8 +7,7 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        mkdir -p /isaac-sim/standalone/{logs,data}"
     volumes:
       - isaac-sim-cache:/isaac-sim
   cartographer-ws:

--- a/cartographer_ws/docker/compose.yaml
+++ b/cartographer_ws/docker/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
       cache_from:
         - j3soon/ros2-cartographer-ws:buildcache-amd64
         - j3soon/ros2-cartographer-ws:buildcache-arm64

--- a/cartographer_ws/docker/compose.yaml
+++ b/cartographer_ws/docker/compose.yaml
@@ -23,7 +23,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
       cache_from:
         - j3soon/ros2-cartographer-ws:buildcache-amd64
         - j3soon/ros2-cartographer-ws:buildcache-arm64

--- a/delto_gripper_ws/.gitignore
+++ b/delto_gripper_ws/.gitignore
@@ -8,3 +8,4 @@
 
 # Soft Links
 /docs
+/docker/modules

--- a/delto_gripper_ws/docker/.bashrc
+++ b/delto_gripper_ws/docker/.bashrc
@@ -7,6 +7,23 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
+echo "changing ownership of Isaac Sim user cache directories..."
+sudo chown user:user /isaac-sim
+sudo chown user:user /isaac-sim/kit
+sudo chown user:user /isaac-sim/kit/cache
+sudo chown user:user /home/user/.cache
+sudo chown user:user /home/user/.cache/ov
+sudo chown user:user /home/user/.cache/pip
+sudo chown user:user /home/user/.cache/nvidia
+sudo chown user:user /home/user/.cache/nvidia/GLCache
+sudo chown user:user /home/user/.nv
+sudo chown user:user /home/user/.nv/ComputeCache
+sudo chown user:user /home/user/.nvidia-omniverse
+sudo chown user:user /home/user/.nvidia-omniverse/logs
+sudo chown user:user /home/user/.local/share/ov
+sudo chown user:user /home/user/.local/share/ov/data
+sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/delto_gripper_ws/docker/.dockerignore
+++ b/delto_gripper_ws/docker/.dockerignore
@@ -1,2 +1,3 @@
 *
 !.bashrc
+!modules

--- a/delto_gripper_ws/docker/Dockerfile
+++ b/delto_gripper_ws/docker/Dockerfile
@@ -88,7 +88,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.5.0.0
+ARG ISAAC_SIM_VERSION=4.5.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/delto_gripper_ws/docker/Dockerfile
+++ b/delto_gripper_ws/docker/Dockerfile
@@ -88,7 +88,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.2.0.2
+ARG ISAAC_SIM_VERSION=4.5.0.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/delto_gripper_ws/docker/Dockerfile
+++ b/delto_gripper_ws/docker/Dockerfile
@@ -45,71 +45,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GUI debugging tools
-# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
-#   Ref: https://packages.debian.org/sid/x11-apps
-#   Ref: https://packages.debian.org/sid/x11-utils
-# - `mesa-utils` for `glxgears` and `glxinfo`
-#   Ref: https://wiki.debian.org/Mesa
-# - `vulkan-tools` for `vkcube` and `vulkaninfo`
-#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
-#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get update && apt-get install -y \
-    x11-apps x11-utils \
-    mesa-utils \
-    libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Install Vulkan config files
-# Ref: https://gitlab.com/nvidia/container-images/vulkan
-# Ref: https://github.com/j3soon/docker-vulkan-runtime
-RUN cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194"
-    }
-}
-EOF
-RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
-    cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libEGL_nvidia.so.0"
-    }
-}
-EOF
-RUN cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "layer": {
-        "name": "VK_LAYER_NV_optimus",
-        "type": "INSTANCE",
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194",
-        "implementation_version" : "1",
-        "description" : "NVIDIA Optimus layer",
-        "functions": {
-            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
-            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
-        },
-        "enable_environment": {
-            "__NV_PRIME_RENDER_OFFLOAD": "1"
-        },
-        "disable_environment": {
-            "DISABLE_LAYER_NV_OPTIMUS_1": ""
-        }
-    }
-}
-EOF
+# Install GUI debugging tools and configure Vulkan
+COPY --chown=root:root modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
 # Install ROS2 Gazebo packages for amd64
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -143,44 +87,14 @@ USER $USERNAME
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
-# Install `libxrandr2` to support Isaac Sim WebRTC streaming
+# Isaac Sim version configuration
+ARG ISAAC_SIM_VERSION=4.2.0.2
+# Copy and run Isaac Sim installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo apt-get update && sudo apt-get install -y \
-        libxrandr2 \
-        && sudo rm -rf /var/lib/apt/lists/*; \
-    fi
-# Install Isaac Sim (requires Python 3.10)
-# Note that installing Isaac Sim with pip is experimental, keep this in mind when unexpected error occurs
-# TODO: Remove the note above when it is no longer experimental
-# Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
-RUN --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        python3 -V | grep "Python 3.10" \
-        && pip install isaacsim==4.2.0.2 --extra-index-url https://pypi.nvidia.com \
-        && pip install isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com; \
-    fi
-
-# Fix SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) `numpy==1.26.0`, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        pip install scipy==1.14.1 numpy==1.26.0; \
-    fi
-
-# Create isaac sim cache directory with correct ownership to avoid permission issues after volume mount, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo mkdir -p /isaac-sim/kit/cache \
-        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache; \
-    fi
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        mkdir -p /home/$USERNAME/.cache/ov \
-        && mkdir -p /home/$USERNAME/.cache/pip \
-        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-        && mkdir -p /home/$USERNAME/.local/share/ov/data \
-        && mkdir -p /home/$USERNAME/Documents; \
-    fi
-
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53

--- a/delto_gripper_ws/docker/Dockerfile
+++ b/delto_gripper_ws/docker/Dockerfile
@@ -102,6 +102,17 @@ ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
 
+# Set TERM to prevent Isaac Lab error during docker build:
+#    'ansi+tabs': unknown terminal type.
+ENV TERM=xterm-256color
+# Isaac Lab version configuration
+ARG ISAAC_LAB_VERSION=2.1.0
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     sudo apt-get update && sudo apt-get install -y \

--- a/delto_gripper_ws/docker/compose.yaml
+++ b/delto_gripper_ws/docker/compose.yaml
@@ -23,7 +23,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
       cache_from:
         - j3soon/ros2-delto-gripper-ws:buildcache-amd64
         - j3soon/ros2-delto-gripper-ws:buildcache-arm64

--- a/delto_gripper_ws/docker/compose.yaml
+++ b/delto_gripper_ws/docker/compose.yaml
@@ -23,6 +23,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
       cache_from:
         - j3soon/ros2-delto-gripper-ws:buildcache-amd64
         - j3soon/ros2-delto-gripper-ws:buildcache-arm64

--- a/delto_gripper_ws/docker/compose.yaml
+++ b/delto_gripper_ws/docker/compose.yaml
@@ -21,6 +21,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
       cache_from:
         - j3soon/ros2-delto-gripper-ws:buildcache-amd64
         - j3soon/ros2-delto-gripper-ws:buildcache-arm64

--- a/delto_gripper_ws/docker/compose.yaml
+++ b/delto_gripper_ws/docker/compose.yaml
@@ -7,8 +7,7 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        mkdir -p /isaac-sim/standalone/{logs,data}"
     volumes:
       - isaac-sim-cache:/isaac-sim
   delto-gripper-ws:

--- a/delto_gripper_ws/docker/compose.yaml
+++ b/delto_gripper_ws/docker/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
       cache_from:
         - j3soon/ros2-delto-gripper-ws:buildcache-amd64
         - j3soon/ros2-delto-gripper-ws:buildcache-arm64

--- a/docker_modules/install_isaac_lab.sh
+++ b/docker_modules/install_isaac_lab.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+# Install Isaac Lab
+
+# Check required environment variables
+if [ -z "$USERNAME" ]; then
+    echo "Error: USERNAME environment variable is required but not set"
+    exit 1
+fi
+if [ -z "$TARGETARCH" ]; then
+    echo "Error: TARGETARCH environment variable is required but not set"
+    exit 1
+fi
+if [ -z "$ISAAC_SIM_VERSION" ]; then
+    echo "Error: ISAAC_SIM_VERSION environment variable is required but not set"
+    exit 1
+fi
+if [ -z "$ISAAC_LAB_VERSION" ]; then
+    echo "Skipping Isaac Lab installation as ISAAC_LAB_VERSION is not set"
+    exit 0
+fi
+
+echo "Installing Isaac Lab for architecture: $TARGETARCH"
+echo "Isaac Lab version: $ISAAC_LAB_VERSION"
+
+# Only install Isaac Lab on amd64 architecture
+if [ "$TARGETARCH" = "amd64" ]; then
+    if [ "$ISAAC_LAB_VERSION" = "2.1.0" ]; then
+        echo "Installing Isaac Lab 2.1.0..."
+        # Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+        sudo apt-get update && sudo apt-get install -y \
+            cmake build-essential \
+            && sudo rm -rf /var/lib/apt/lists/*
+        git clone -b v2.1.0 https://github.com/isaac-sim/IsaacLab.git ~/IsaacLab \
+            && cd ~/IsaacLab \
+            && ln -s ${HOME}/isaacsim _isaac_sim \
+            && ./isaaclab.sh --install
+    else
+        echo "Error: Unsupported Isaac Lab version: $ISAAC_LAB_VERSION"
+        exit 1
+    fi
+    echo "Isaac Lab installation completed successfully!"
+else
+    echo "Skipping Isaac Lab installation for architecture: $TARGETARCH (only supported on amd64)"
+fi

--- a/docker_modules/install_isaac_sim.sh
+++ b/docker_modules/install_isaac_sim.sh
@@ -32,8 +32,8 @@ if [ "$TARGETARCH" = "amd64" ]; then
     # TODO: Remove the note above when it is no longer experimental
     # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
     python3 -V | grep "Python 3.10" \
-        && pip install isaacsim==$ISAAC_SIM_VERSION --extra-index-url https://pypi.nvidia.com \
-        && pip install isaacsim-extscache-physics==$ISAAC_SIM_VERSION isaacsim-extscache-kit==$ISAAC_SIM_VERSION isaacsim-extscache-kit-sdk==$ISAAC_SIM_VERSION --extra-index-url https://pypi.nvidia.com
+        && pip install isaacsim[all]==$ISAAC_SIM_VERSION --extra-index-url https://pypi.nvidia.com \
+        && pip install isaacsim[extscache]==$ISAAC_SIM_VERSION --extra-index-url https://pypi.nvidia.com
 
     echo "Fixing SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) numpy==1.26.0..."
     pip install scipy==1.14.1 numpy==1.26.0

--- a/docker_modules/install_isaac_sim.sh
+++ b/docker_modules/install_isaac_sim.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+# Install Isaac Sim related components
+
+# Check required environment variables
+if [ -z "$USERNAME" ]; then
+    echo "Error: USERNAME environment variable is required but not set"
+    exit 1
+fi
+if [ -z "$TARGETARCH" ]; then
+    echo "Error: TARGETARCH environment variable is required but not set"
+    exit 1
+fi
+if [ -z "$ISAAC_SIM_VERSION" ]; then
+    echo "Skipping Isaac Sim installation as ISAAC_SIM_VERSION is not set"
+    exit 0
+fi
+
+echo "Installing Isaac Sim components for architecture: $TARGETARCH"
+echo "Isaac Sim version: $ISAAC_SIM_VERSION"
+
+# Only install Isaac Sim components on amd64 architecture
+if [ "$TARGETARCH" = "amd64" ]; then
+    echo "Installing libxrandr2 to support Isaac Sim WebRTC streaming..."
+    sudo apt-get update && sudo apt-get install -y \
+        libxrandr2 \
+        && sudo rm -rf /var/lib/apt/lists/*
+
+    echo "Installing Isaac Sim (requires Python 3.10)..."
+    # Note that installing Isaac Sim with pip is experimental, keep this in mind when unexpected error occurs
+    # TODO: Remove the note above when it is no longer experimental
+    # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
+    python3 -V | grep "Python 3.10" \
+        && pip install isaacsim==$ISAAC_SIM_VERSION --extra-index-url https://pypi.nvidia.com \
+        && pip install isaacsim-extscache-physics==$ISAAC_SIM_VERSION isaacsim-extscache-kit==$ISAAC_SIM_VERSION isaacsim-extscache-kit-sdk==$ISAAC_SIM_VERSION --extra-index-url https://pypi.nvidia.com
+
+    echo "Fixing SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) numpy==1.26.0..."
+    pip install scipy==1.14.1 numpy==1.26.0
+
+    echo "Creating isaac sim cache directory with correct ownership..."
+    sudo mkdir -p /isaac-sim/kit/cache \
+        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache
+
+    echo "Creating Isaac Sim user cache directories..."
+    mkdir -p /home/$USERNAME/.cache/ov \
+        && mkdir -p /home/$USERNAME/.cache/pip \
+        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
+        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
+        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
+        && mkdir -p /home/$USERNAME/.local/share/ov/data \
+        && mkdir -p /home/$USERNAME/Documents
+
+    echo "Isaac Sim installation completed successfully!"
+else
+    echo "Skipping Isaac Sim installation for architecture: $TARGETARCH (only supported on amd64)"
+fi

--- a/docker_modules/install_isaac_sim.sh
+++ b/docker_modules/install_isaac_sim.sh
@@ -38,19 +38,6 @@ if [ "$TARGETARCH" = "amd64" ]; then
     echo "Fixing SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) numpy==1.26.0..."
     pip install scipy==1.14.1 numpy==1.26.0
 
-    echo "Creating isaac sim cache directory with correct ownership..."
-    sudo mkdir -p /isaac-sim/kit/cache \
-        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache
-
-    echo "Creating Isaac Sim user cache directories..."
-    mkdir -p /home/$USERNAME/.cache/ov \
-        && mkdir -p /home/$USERNAME/.cache/pip \
-        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-        && mkdir -p /home/$USERNAME/.local/share/ov/data \
-        && mkdir -p /home/$USERNAME/Documents
-
     echo "Isaac Sim installation completed successfully!"
 else
     echo "Skipping Isaac Sim installation for architecture: $TARGETARCH (only supported on amd64)"

--- a/docker_modules/install_x11_opengl_vulkan.sh
+++ b/docker_modules/install_x11_opengl_vulkan.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+
+# Install GUI debugging tools and configure Vulkan support
+
+echo "Installing GUI debugging tools..."
+# Install GUI debugging tools
+# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
+#   Ref: https://packages.debian.org/sid/x11-apps
+#   Ref: https://packages.debian.org/sid/x11-utils
+# - `mesa-utils` for `glxgears` and `glxinfo`
+#   Ref: https://wiki.debian.org/Mesa
+# - `vulkan-tools` for `vkcube` and `vulkaninfo`
+#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
+#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
+apt-get update && apt-get install -y \
+    x11-apps x11-utils \
+    mesa-utils \
+    libgl1 vulkan-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+echo "Configuring Vulkan support..."
+# Install Vulkan config files
+# Ref: https://gitlab.com/nvidia/container-images/vulkan
+# Ref: https://github.com/j3soon/docker-vulkan-runtime
+cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
+{
+    "file_format_version" : "1.0.0",
+    "ICD": {
+        "library_path": "libGLX_nvidia.so.0",
+        "api_version" : "1.3.194"
+    }
+}
+EOF
+
+mkdir -p /usr/share/glvnd/egl_vendor.d
+cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
+{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_nvidia.so.0"
+    }
+}
+EOF
+
+cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
+{
+    "file_format_version" : "1.0.0",
+    "layer": {
+        "name": "VK_LAYER_NV_optimus",
+        "type": "INSTANCE",
+        "library_path": "libGLX_nvidia.so.0",
+        "api_version" : "1.3.194",
+        "implementation_version" : "1",
+        "description" : "NVIDIA Optimus layer",
+        "functions": {
+            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
+            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
+        },
+        "enable_environment": {
+            "__NV_PRIME_RENDER_OFFLOAD": "1"
+        },
+        "disable_environment": {
+            "DISABLE_LAYER_NV_OPTIMUS_1": ""
+        }
+    }
+}
+EOF
+
+echo "GUI debugging tools and Vulkan configuration completed successfully!"

--- a/docs/aloha-ws/index.md
+++ b/docs/aloha-ws/index.md
@@ -98,7 +98,7 @@ ros2 launch interbotix_xsarm_moveit xsarm_moveit.launch.py robot_model:=vx300s h
 The Isaac Sim app can be launched with:
 
 ```sh
-isaacsim omni.isaac.sim
+isaacsim isaacsim.exp.full
 ```
 
 Keep in mind that the standalone scripts can be easily debugged in Isaac Sim's `Script Editor`.
@@ -126,7 +126,7 @@ ros2 topic echo /vx300s/joint_states
 A specific world can also be directly launched and played with:
 
 ```sh
-isaacsim omni.isaac.sim --exec '/home/ros2-essentials/aloha_ws/isaacsim/scripts/open_isaacsim_stage.py --path /home/ros2-essentials/aloha_ws/isaacsim/assets/vx300s_og.usd'
+isaacsim isaacsim.exp.full --exec '/home/ros2-essentials/aloha_ws/isaacsim/scripts/open_isaacsim_stage.py --path /home/ros2-essentials/aloha_ws/isaacsim/assets/vx300s_og.usd'
 ```
 
 To access Nucleus from Isaac Sim, you should [install Nucleus](https://docs.omniverse.nvidia.com/nucleus/latest/workstation/installation.html) with default username/password `admin:admin` on your host machine or connect to an external Nucleus server.

--- a/docs/aloha-ws/index.md
+++ b/docs/aloha-ws/index.md
@@ -98,7 +98,7 @@ ros2 launch interbotix_xsarm_moveit xsarm_moveit.launch.py robot_model:=vx300s h
 The Isaac Sim app can be launched with:
 
 ```sh
-isaacsim isaacsim.exp.full
+~/isaacsim/isaac-sim.sh
 ```
 
 Keep in mind that the standalone scripts can be easily debugged in Isaac Sim's `Script Editor`.
@@ -126,7 +126,7 @@ ros2 topic echo /vx300s/joint_states
 A specific world can also be directly launched and played with:
 
 ```sh
-isaacsim isaacsim.exp.full --exec '/home/ros2-essentials/aloha_ws/isaacsim/scripts/open_isaacsim_stage.py --path /home/ros2-essentials/aloha_ws/isaacsim/assets/vx300s_og.usd'
+~/isaacsim/isaac-sim.sh --exec '/home/ros2-essentials/aloha_ws/isaacsim/scripts/open_isaacsim_stage.py --path /home/ros2-essentials/aloha_ws/isaacsim/assets/vx300s_og.usd'
 ```
 
 To access Nucleus from Isaac Sim, you should [install Nucleus](https://docs.omniverse.nvidia.com/nucleus/latest/workstation/installation.html) with default username/password `admin:admin` on your host machine or connect to an external Nucleus server.

--- a/docs/delto-gripper-ws/index.md
+++ b/docs/delto-gripper-ws/index.md
@@ -34,7 +34,7 @@ colcon build --symlink-install
 ### Launch the Isaacsim
 
 ```bash
-isaacsim omni.isaac.sim
+isaacsim isaacsim.exp.full
 ```
 
 > After the Isaacsim is launched, open the delto gripper usd file and play the simulation.  

--- a/docs/delto-gripper-ws/index.md
+++ b/docs/delto-gripper-ws/index.md
@@ -34,7 +34,7 @@ colcon build --symlink-install
 ### Launch the Isaacsim
 
 ```bash
-isaacsim isaacsim.exp.full
+~/isaacsim/isaac-sim.sh
 ```
 
 > After the Isaacsim is launched, open the delto gripper usd file and play the simulation.  

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,6 +118,15 @@ docker buildx rm -f --all-inactive
 
 The GitHub Actions workflow is designed to share build caches between workspaces efficiently. The template workspace is built first, and its cache is then reused by other workspaces. This means that while the template workspace build appears in the commit history, other workspace builds are triggered indirectly and only show up in the GitHub Actions tab. For implementation details, see [commit `024f52a`](https://github.com/j3soon/ros2-essentials/commit/024f52a2bb8a58ad20c03a067560215e8cef6307).
 
+Some current CI builds are flaky and may require re-running.
+
+### Docker Compose Cleanup
+
+```sh
+# cd into a workspace directory's docker directory
+docker compose down --volumes --remove-orphans
+```
+
 ## Acknowledgement
 
 The code is mainly contributed by [Johnson](https://github.com/j3soon), [Yu-Zhong Chen](https://github.com/YuZhong-Chen), [Assume Zhan](https://github.com/Assume-Zhan), [Lam Chon Hang](https://github.com/ClassLongJoe1112), and others. For a full list of contributors, please refer to the [contribution list](https://github.com/j3soon/ros2-essentials/graphs/contributors).

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,13 +72,17 @@ mkdocs serve
 scripts/setup_docs_link.sh
 ```
 
+This is automatically done by running `./scripts/post_install.sh`.
+
 ## VSCode Intellisense
 
-If you have installed Isaac Sim 4.2.0 from [Omniverse Launcher](https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_workstation.html) to the default path `~/.local/share/ov/pkg/isaac-sim-4.2.0`, you can simply enable IntelliSense for editing any Isaac Sim scripts by running the following script:
+If you have installed [Isaac Sim 4.5.0](https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/install_workstation.html) to the default path `~/isaacsim`, you can simply enable IntelliSense for editing any Isaac Sim scripts by running the following script:
 
 ```sh
 scripts/setup_isaac_link.sh
 ```
+
+This is automatically done by running `./scripts/post_install.sh`.
 
 ## Reusing Docker Build Cache
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ The documentation is hosted on <https://j3soon.github.io/ros2-essentials/>.
 ```sh
 git clone https://github.com/j3soon/ros2-essentials.git
 cd ros2-essentials
+./scripts/post_install.sh
 ```
 
 ## Pre-built Workspaces

--- a/docs/turtlebot3-ws/index.md
+++ b/docs/turtlebot3-ws/index.md
@@ -83,13 +83,13 @@ python3 create_turtlebot3_burger_with_omnigraph.py
 Start Isaac Sim in GUI mode:
 
 ```sh
-isaacsim isaacsim.exp.full
+~/isaacsim/isaac-sim.sh
 ```
 
 > Alternatively, start Isaac Sim in [headless WebRTC mode](https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/install_python.html#launching-isaac-sim-experiences):
 > 
 > ```sh
-> isaacsim isaacsim.exp.full.streaming --no-window
+> isaac-sim.streaming.sh
 > ```
 >
 > and use the [WebRTC Streaming Client](https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/manual_livestream_clients.html#isaac-sim-short-webrtc-streaming-client).

--- a/docs/turtlebot3-ws/index.md
+++ b/docs/turtlebot3-ws/index.md
@@ -83,16 +83,16 @@ python3 create_turtlebot3_burger_with_omnigraph.py
 Start Isaac Sim in GUI mode:
 
 ```sh
-isaacsim omni.isaac.sim
+isaacsim isaacsim.exp.full
 ```
 
-> Alternatively, start Isaac Sim in headless WebRTC mode:
+> Alternatively, start Isaac Sim in [headless WebRTC mode](https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/install_python.html#launching-isaac-sim-experiences):
 > 
 > ```sh
-> isaacsim omni.isaac.sim.headless.webrtc --no-window
+> isaacsim isaacsim.exp.full.streaming --no-window
 > ```
 >
-> and visit <http://127.0.0.1:8211/streaming/webrtc-demo/?server=127.0.0.1> to stream through WebRTC.
+> and use the [WebRTC Streaming Client](https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/manual_livestream_clients.html#isaac-sim-short-webrtc-streaming-client).
 
 Open the file with OmniGraph we just generated in the bottom panel:
 

--- a/gazebo_world_ws/.gitignore
+++ b/gazebo_world_ws/.gitignore
@@ -8,3 +8,4 @@
 
 # Soft Links
 /docs
+/docker/modules

--- a/gazebo_world_ws/docker/.bashrc
+++ b/gazebo_world_ws/docker/.bashrc
@@ -7,6 +7,23 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
+echo "changing ownership of Isaac Sim user cache directories..."
+sudo chown user:user /isaac-sim
+sudo chown user:user /isaac-sim/kit
+sudo chown user:user /isaac-sim/kit/cache
+sudo chown user:user /home/user/.cache
+sudo chown user:user /home/user/.cache/ov
+sudo chown user:user /home/user/.cache/pip
+sudo chown user:user /home/user/.cache/nvidia
+sudo chown user:user /home/user/.cache/nvidia/GLCache
+sudo chown user:user /home/user/.nv
+sudo chown user:user /home/user/.nv/ComputeCache
+sudo chown user:user /home/user/.nvidia-omniverse
+sudo chown user:user /home/user/.nvidia-omniverse/logs
+sudo chown user:user /home/user/.local/share/ov
+sudo chown user:user /home/user/.local/share/ov/data
+sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/gazebo_world_ws/docker/.dockerignore
+++ b/gazebo_world_ws/docker/.dockerignore
@@ -1,2 +1,3 @@
 *
 !.bashrc
+!modules

--- a/gazebo_world_ws/docker/Dockerfile
+++ b/gazebo_world_ws/docker/Dockerfile
@@ -47,71 +47,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GUI debugging tools
-# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
-#   Ref: https://packages.debian.org/sid/x11-apps
-#   Ref: https://packages.debian.org/sid/x11-utils
-# - `mesa-utils` for `glxgears` and `glxinfo`
-#   Ref: https://wiki.debian.org/Mesa
-# - `vulkan-tools` for `vkcube` and `vulkaninfo`
-#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
-#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get update && apt-get install -y \
-    x11-apps x11-utils \
-    mesa-utils \
-    libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Install Vulkan config files
-# Ref: https://gitlab.com/nvidia/container-images/vulkan
-# Ref: https://github.com/j3soon/docker-vulkan-runtime
-RUN cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194"
-    }
-}
-EOF
-RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
-    cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libEGL_nvidia.so.0"
-    }
-}
-EOF
-RUN cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "layer": {
-        "name": "VK_LAYER_NV_optimus",
-        "type": "INSTANCE",
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194",
-        "implementation_version" : "1",
-        "description" : "NVIDIA Optimus layer",
-        "functions": {
-            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
-            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
-        },
-        "enable_environment": {
-            "__NV_PRIME_RENDER_OFFLOAD": "1"
-        },
-        "disable_environment": {
-            "DISABLE_LAYER_NV_OPTIMUS_1": ""
-        }
-    }
-}
-EOF
+# Install GUI debugging tools and configure Vulkan
+COPY --chown=root:root modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
 # Install ROS2 Gazebo packages for amd64
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -145,44 +89,14 @@ USER $USERNAME
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
-# Install `libxrandr2` to support Isaac Sim WebRTC streaming
+# Isaac Sim version configuration
+ARG ISAAC_SIM_VERSION=4.2.0.2
+# Copy and run Isaac Sim installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo apt-get update && sudo apt-get install -y \
-        libxrandr2 \
-        && sudo rm -rf /var/lib/apt/lists/*; \
-    fi
-# Install Isaac Sim (requires Python 3.10)
-# Note that installing Isaac Sim with pip is experimental, keep this in mind when unexpected error occurs
-# TODO: Remove the note above when it is no longer experimental
-# Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
-RUN --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        python3 -V | grep "Python 3.10" \
-        && pip install isaacsim==4.2.0.2 --extra-index-url https://pypi.nvidia.com \
-        && pip install isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com; \
-    fi
-
-# Fix SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) `numpy==1.26.0`, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        pip install scipy==1.14.1 numpy==1.26.0; \
-    fi
-
-# Create isaac sim cache directory with correct ownership to avoid permission issues after volume mount, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo mkdir -p /isaac-sim/kit/cache \
-        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache; \
-    fi
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        mkdir -p /home/$USERNAME/.cache/ov \
-        && mkdir -p /home/$USERNAME/.cache/pip \
-        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-        && mkdir -p /home/$USERNAME/.local/share/ov/data \
-        && mkdir -p /home/$USERNAME/Documents; \
-    fi
-
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53

--- a/gazebo_world_ws/docker/Dockerfile
+++ b/gazebo_world_ws/docker/Dockerfile
@@ -90,7 +90,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.5.0.0
+ARG ISAAC_SIM_VERSION=4.5.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/gazebo_world_ws/docker/Dockerfile
+++ b/gazebo_world_ws/docker/Dockerfile
@@ -90,7 +90,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.2.0.2
+ARG ISAAC_SIM_VERSION=4.5.0.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/gazebo_world_ws/docker/Dockerfile
+++ b/gazebo_world_ws/docker/Dockerfile
@@ -104,6 +104,17 @@ ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
 
+# Set TERM to prevent Isaac Lab error during docker build:
+#    'ansi+tabs': unknown terminal type.
+ENV TERM=xterm-256color
+# Isaac Lab version configuration
+ARG ISAAC_LAB_VERSION=2.1.0
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     sudo apt-get update && sudo apt-get install -y \

--- a/gazebo_world_ws/docker/compose.yaml
+++ b/gazebo_world_ws/docker/compose.yaml
@@ -7,8 +7,7 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        mkdir -p /isaac-sim/standalone/{logs,data}"
     volumes:
       - isaac-sim-cache:/isaac-sim
   gazebo-world-ws:

--- a/gazebo_world_ws/docker/compose.yaml
+++ b/gazebo_world_ws/docker/compose.yaml
@@ -23,6 +23,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
       cache_from:
         - j3soon/ros2-gazebo-world-ws:buildcache-amd64
         - j3soon/ros2-gazebo-world-ws:buildcache-arm64

--- a/gazebo_world_ws/docker/compose.yaml
+++ b/gazebo_world_ws/docker/compose.yaml
@@ -23,7 +23,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
       cache_from:
         - j3soon/ros2-gazebo-world-ws:buildcache-amd64
         - j3soon/ros2-gazebo-world-ws:buildcache-arm64

--- a/gazebo_world_ws/docker/compose.yaml
+++ b/gazebo_world_ws/docker/compose.yaml
@@ -21,6 +21,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
       cache_from:
         - j3soon/ros2-gazebo-world-ws:buildcache-amd64
         - j3soon/ros2-gazebo-world-ws:buildcache-arm64

--- a/gazebo_world_ws/docker/compose.yaml
+++ b/gazebo_world_ws/docker/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
       cache_from:
         - j3soon/ros2-gazebo-world-ws:buildcache-amd64
         - j3soon/ros2-gazebo-world-ws:buildcache-arm64

--- a/husky_ws/.gitignore
+++ b/husky_ws/.gitignore
@@ -8,3 +8,4 @@
 
 # Soft Links
 /docs
+/docker/modules

--- a/husky_ws/docker/.bashrc
+++ b/husky_ws/docker/.bashrc
@@ -7,6 +7,23 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
+echo "changing ownership of Isaac Sim user cache directories..."
+sudo chown user:user /isaac-sim
+sudo chown user:user /isaac-sim/kit
+sudo chown user:user /isaac-sim/kit/cache
+sudo chown user:user /home/user/.cache
+sudo chown user:user /home/user/.cache/ov
+sudo chown user:user /home/user/.cache/pip
+sudo chown user:user /home/user/.cache/nvidia
+sudo chown user:user /home/user/.cache/nvidia/GLCache
+sudo chown user:user /home/user/.nv
+sudo chown user:user /home/user/.nv/ComputeCache
+sudo chown user:user /home/user/.nvidia-omniverse
+sudo chown user:user /home/user/.nvidia-omniverse/logs
+sudo chown user:user /home/user/.local/share/ov
+sudo chown user:user /home/user/.local/share/ov/data
+sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/husky_ws/docker/.dockerignore
+++ b/husky_ws/docker/.dockerignore
@@ -1,5 +1,6 @@
 *
 !.bashrc
+!modules
 !script
 !clearpath_computer_installer
 !udev_rules

--- a/husky_ws/docker/Dockerfile
+++ b/husky_ws/docker/Dockerfile
@@ -47,71 +47,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GUI debugging tools
-# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
-#   Ref: https://packages.debian.org/sid/x11-apps
-#   Ref: https://packages.debian.org/sid/x11-utils
-# - `mesa-utils` for `glxgears` and `glxinfo`
-#   Ref: https://wiki.debian.org/Mesa
-# - `vulkan-tools` for `vkcube` and `vulkaninfo`
-#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
-#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get update && apt-get install -y \
-    x11-apps x11-utils \
-    mesa-utils \
-    libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Install Vulkan config files
-# Ref: https://gitlab.com/nvidia/container-images/vulkan
-# Ref: https://github.com/j3soon/docker-vulkan-runtime
-RUN cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194"
-    }
-}
-EOF
-RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
-    cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libEGL_nvidia.so.0"
-    }
-}
-EOF
-RUN cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "layer": {
-        "name": "VK_LAYER_NV_optimus",
-        "type": "INSTANCE",
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194",
-        "implementation_version" : "1",
-        "description" : "NVIDIA Optimus layer",
-        "functions": {
-            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
-            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
-        },
-        "enable_environment": {
-            "__NV_PRIME_RENDER_OFFLOAD": "1"
-        },
-        "disable_environment": {
-            "DISABLE_LAYER_NV_OPTIMUS_1": ""
-        }
-    }
-}
-EOF
+# Install GUI debugging tools and configure Vulkan
+COPY --chown=root:root modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
 # Install ROS2 Gazebo packages for amd64
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -145,44 +89,14 @@ USER $USERNAME
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
-# Install `libxrandr2` to support Isaac Sim WebRTC streaming
+# Isaac Sim version configuration
+ARG ISAAC_SIM_VERSION=4.2.0.2
+# Copy and run Isaac Sim installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo apt-get update && sudo apt-get install -y \
-        libxrandr2 \
-        && sudo rm -rf /var/lib/apt/lists/*; \
-    fi
-# Install Isaac Sim (requires Python 3.10)
-# Note that installing Isaac Sim with pip is experimental, keep this in mind when unexpected error occurs
-# TODO: Remove the note above when it is no longer experimental
-# Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
-RUN --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        python3 -V | grep "Python 3.10" \
-        && pip install isaacsim==4.2.0.2 --extra-index-url https://pypi.nvidia.com \
-        && pip install isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com; \
-    fi
-
-# Fix SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) `numpy==1.26.0`, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        pip install scipy==1.14.1 numpy==1.26.0; \
-    fi
-
-# Create isaac sim cache directory with correct ownership to avoid permission issues after volume mount, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo mkdir -p /isaac-sim/kit/cache \
-        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache; \
-    fi
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        mkdir -p /home/$USERNAME/.cache/ov \
-        && mkdir -p /home/$USERNAME/.cache/pip \
-        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-        && mkdir -p /home/$USERNAME/.local/share/ov/data \
-        && mkdir -p /home/$USERNAME/Documents; \
-    fi
-
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53

--- a/husky_ws/docker/Dockerfile
+++ b/husky_ws/docker/Dockerfile
@@ -90,7 +90,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.5.0.0
+ARG ISAAC_SIM_VERSION=4.5.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/husky_ws/docker/Dockerfile
+++ b/husky_ws/docker/Dockerfile
@@ -90,7 +90,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.2.0.2
+ARG ISAAC_SIM_VERSION=4.5.0.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/husky_ws/docker/Dockerfile
+++ b/husky_ws/docker/Dockerfile
@@ -104,6 +104,17 @@ ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
 
+# Set TERM to prevent Isaac Lab error during docker build:
+#    'ansi+tabs': unknown terminal type.
+ENV TERM=xterm-256color
+# Isaac Lab version configuration
+ARG ISAAC_LAB_VERSION=2.1.0
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     sudo apt-get update && sudo apt-get install -y \

--- a/husky_ws/docker/compose.yaml
+++ b/husky_ws/docker/compose.yaml
@@ -7,8 +7,7 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        mkdir -p /isaac-sim/standalone/{logs,data}"
     volumes:
       - isaac-sim-cache:/isaac-sim
   husky-ws:

--- a/husky_ws/docker/compose.yaml
+++ b/husky_ws/docker/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
       cache_from:
         - j3soon/ros2-husky-ws:buildcache-amd64
         - j3soon/ros2-husky-ws:buildcache-arm64

--- a/husky_ws/docker/compose.yaml
+++ b/husky_ws/docker/compose.yaml
@@ -21,6 +21,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
       cache_from:
         - j3soon/ros2-husky-ws:buildcache-amd64
         - j3soon/ros2-husky-ws:buildcache-arm64

--- a/husky_ws/docker/compose.yaml
+++ b/husky_ws/docker/compose.yaml
@@ -23,7 +23,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
       cache_from:
         - j3soon/ros2-husky-ws:buildcache-amd64
         - j3soon/ros2-husky-ws:buildcache-arm64

--- a/husky_ws/docker/compose.yaml
+++ b/husky_ws/docker/compose.yaml
@@ -23,6 +23,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
       cache_from:
         - j3soon/ros2-husky-ws:buildcache-amd64
         - j3soon/ros2-husky-ws:buildcache-arm64

--- a/jazzy_template_ws/.gitignore
+++ b/jazzy_template_ws/.gitignore
@@ -8,3 +8,4 @@
 
 # Soft Links
 /docs
+/docker/modules

--- a/jazzy_template_ws/docker/.bashrc
+++ b/jazzy_template_ws/docker/.bashrc
@@ -7,6 +7,23 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
+echo "changing ownership of Isaac Sim user cache directories..."
+sudo chown user:user /isaac-sim
+sudo chown user:user /isaac-sim/kit
+sudo chown user:user /isaac-sim/kit/cache
+sudo chown user:user /home/user/.cache
+sudo chown user:user /home/user/.cache/ov
+sudo chown user:user /home/user/.cache/pip
+sudo chown user:user /home/user/.cache/nvidia
+sudo chown user:user /home/user/.cache/nvidia/GLCache
+sudo chown user:user /home/user/.nv
+sudo chown user:user /home/user/.nv/ComputeCache
+sudo chown user:user /home/user/.nvidia-omniverse
+sudo chown user:user /home/user/.nvidia-omniverse/logs
+sudo chown user:user /home/user/.local/share/ov
+sudo chown user:user /home/user/.local/share/ov/data
+sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/jazzy_template_ws/docker/.dockerignore
+++ b/jazzy_template_ws/docker/.dockerignore
@@ -1,2 +1,3 @@
 *
 !.bashrc
+!modules

--- a/jazzy_template_ws/docker/Dockerfile
+++ b/jazzy_template_ws/docker/Dockerfile
@@ -61,71 +61,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GUI debugging tools
-# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
-#   Ref: https://packages.debian.org/sid/x11-apps
-#   Ref: https://packages.debian.org/sid/x11-utils
-# - `mesa-utils` for `glxgears` and `glxinfo`
-#   Ref: https://wiki.debian.org/Mesa
-# - `vulkan-tools` for `vkcube` and `vulkaninfo`
-#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
-#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get update && apt-get install -y \
-    x11-apps x11-utils \
-    mesa-utils \
-    libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Install Vulkan config files
-# Ref: https://gitlab.com/nvidia/container-images/vulkan
-# Ref: https://github.com/j3soon/docker-vulkan-runtime
-RUN cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194"
-    }
-}
-EOF
-RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
-    cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libEGL_nvidia.so.0"
-    }
-}
-EOF
-RUN cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "layer": {
-        "name": "VK_LAYER_NV_optimus",
-        "type": "INSTANCE",
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194",
-        "implementation_version" : "1",
-        "description" : "NVIDIA Optimus layer",
-        "functions": {
-            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
-            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
-        },
-        "enable_environment": {
-            "__NV_PRIME_RENDER_OFFLOAD": "1"
-        },
-        "disable_environment": {
-            "DISABLE_LAYER_NV_OPTIMUS_1": ""
-        }
-    }
-}
-EOF
+# Install GUI debugging tools and configure Vulkan
+COPY --chown=root:root modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
 # Install ROS2 Gazebo packages for amd64
 # Note that Gazebo Classic is EOL and should switch to the latest Gazebo

--- a/jazzy_template_ws/docker/compose.yaml
+++ b/jazzy_template_ws/docker/compose.yaml
@@ -23,7 +23,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
     image: j3soon/ros2-jazzy-template-ws
     container_name: ros2-jazzy-template-ws
     stdin_open: true

--- a/jazzy_template_ws/docker/compose.yaml
+++ b/jazzy_template_ws/docker/compose.yaml
@@ -7,8 +7,7 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        mkdir -p /isaac-sim/standalone/{logs,data}"
     volumes:
       - isaac-sim-cache:/isaac-sim
   jazzy-template-ws:

--- a/jazzy_template_ws/docker/compose.yaml
+++ b/jazzy_template_ws/docker/compose.yaml
@@ -23,6 +23,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
     image: j3soon/ros2-jazzy-template-ws
     container_name: ros2-jazzy-template-ws
     stdin_open: true

--- a/jazzy_template_ws/docker/compose.yaml
+++ b/jazzy_template_ws/docker/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
     image: j3soon/ros2-jazzy-template-ws
     container_name: ros2-jazzy-template-ws
     stdin_open: true

--- a/jazzy_template_ws/docker/compose.yaml
+++ b/jazzy_template_ws/docker/compose.yaml
@@ -21,6 +21,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
     image: j3soon/ros2-jazzy-template-ws
     container_name: ros2-jazzy-template-ws
     stdin_open: true

--- a/kobuki_ws/.gitignore
+++ b/kobuki_ws/.gitignore
@@ -8,3 +8,4 @@
 
 # Soft Links
 /docs
+/docker/modules

--- a/kobuki_ws/docker/.bashrc
+++ b/kobuki_ws/docker/.bashrc
@@ -7,6 +7,23 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
+echo "changing ownership of Isaac Sim user cache directories..."
+sudo chown user:user /isaac-sim
+sudo chown user:user /isaac-sim/kit
+sudo chown user:user /isaac-sim/kit/cache
+sudo chown user:user /home/user/.cache
+sudo chown user:user /home/user/.cache/ov
+sudo chown user:user /home/user/.cache/pip
+sudo chown user:user /home/user/.cache/nvidia
+sudo chown user:user /home/user/.cache/nvidia/GLCache
+sudo chown user:user /home/user/.nv
+sudo chown user:user /home/user/.nv/ComputeCache
+sudo chown user:user /home/user/.nvidia-omniverse
+sudo chown user:user /home/user/.nvidia-omniverse/logs
+sudo chown user:user /home/user/.local/share/ov
+sudo chown user:user /home/user/.local/share/ov/data
+sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/kobuki_ws/docker/.dockerignore
+++ b/kobuki_ws/docker/.dockerignore
@@ -1,4 +1,5 @@
 *
 !.bashrc
+!modules
 !kobuki_driver_ws
 !udev_rules

--- a/kobuki_ws/docker/Dockerfile
+++ b/kobuki_ws/docker/Dockerfile
@@ -47,71 +47,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GUI debugging tools
-# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
-#   Ref: https://packages.debian.org/sid/x11-apps
-#   Ref: https://packages.debian.org/sid/x11-utils
-# - `mesa-utils` for `glxgears` and `glxinfo`
-#   Ref: https://wiki.debian.org/Mesa
-# - `vulkan-tools` for `vkcube` and `vulkaninfo`
-#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
-#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get update && apt-get install -y \
-    x11-apps x11-utils \
-    mesa-utils \
-    libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Install Vulkan config files
-# Ref: https://gitlab.com/nvidia/container-images/vulkan
-# Ref: https://github.com/j3soon/docker-vulkan-runtime
-RUN cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194"
-    }
-}
-EOF
-RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
-    cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libEGL_nvidia.so.0"
-    }
-}
-EOF
-RUN cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "layer": {
-        "name": "VK_LAYER_NV_optimus",
-        "type": "INSTANCE",
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194",
-        "implementation_version" : "1",
-        "description" : "NVIDIA Optimus layer",
-        "functions": {
-            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
-            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
-        },
-        "enable_environment": {
-            "__NV_PRIME_RENDER_OFFLOAD": "1"
-        },
-        "disable_environment": {
-            "DISABLE_LAYER_NV_OPTIMUS_1": ""
-        }
-    }
-}
-EOF
+# Install GUI debugging tools and configure Vulkan
+COPY --chown=root:root modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
 # Install ROS2 Gazebo packages for amd64
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -145,44 +89,14 @@ USER $USERNAME
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
-# Install `libxrandr2` to support Isaac Sim WebRTC streaming
+# Isaac Sim version configuration
+ARG ISAAC_SIM_VERSION=4.2.0.2
+# Copy and run Isaac Sim installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo apt-get update && sudo apt-get install -y \
-        libxrandr2 \
-        && sudo rm -rf /var/lib/apt/lists/*; \
-    fi
-# Install Isaac Sim (requires Python 3.10)
-# Note that installing Isaac Sim with pip is experimental, keep this in mind when unexpected error occurs
-# TODO: Remove the note above when it is no longer experimental
-# Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
-RUN --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        python3 -V | grep "Python 3.10" \
-        && pip install isaacsim==4.2.0.2 --extra-index-url https://pypi.nvidia.com \
-        && pip install isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com; \
-    fi
-
-# Fix SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) `numpy==1.26.0`, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        pip install scipy==1.14.1 numpy==1.26.0; \
-    fi
-
-# Create isaac sim cache directory with correct ownership to avoid permission issues after volume mount, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo mkdir -p /isaac-sim/kit/cache \
-        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache; \
-    fi
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        mkdir -p /home/$USERNAME/.cache/ov \
-        && mkdir -p /home/$USERNAME/.cache/pip \
-        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-        && mkdir -p /home/$USERNAME/.local/share/ov/data \
-        && mkdir -p /home/$USERNAME/Documents; \
-    fi
-
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53

--- a/kobuki_ws/docker/Dockerfile
+++ b/kobuki_ws/docker/Dockerfile
@@ -90,7 +90,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.5.0.0
+ARG ISAAC_SIM_VERSION=4.5.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/kobuki_ws/docker/Dockerfile
+++ b/kobuki_ws/docker/Dockerfile
@@ -90,7 +90,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.2.0.2
+ARG ISAAC_SIM_VERSION=4.5.0.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/kobuki_ws/docker/Dockerfile
+++ b/kobuki_ws/docker/Dockerfile
@@ -104,6 +104,17 @@ ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
 
+# Set TERM to prevent Isaac Lab error during docker build:
+#    'ansi+tabs': unknown terminal type.
+ENV TERM=xterm-256color
+# Isaac Lab version configuration
+ARG ISAAC_LAB_VERSION=2.1.0
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     sudo apt-get update && sudo apt-get install -y \

--- a/kobuki_ws/docker/compose.yaml
+++ b/kobuki_ws/docker/compose.yaml
@@ -23,6 +23,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
       cache_from:
         - j3soon/ros2-kobuki-ws:buildcache-amd64
         - j3soon/ros2-kobuki-ws:buildcache-arm64

--- a/kobuki_ws/docker/compose.yaml
+++ b/kobuki_ws/docker/compose.yaml
@@ -7,8 +7,7 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        mkdir -p /isaac-sim/standalone/{logs,data}"
     volumes:
       - isaac-sim-cache:/isaac-sim
   kobuki-ws:

--- a/kobuki_ws/docker/compose.yaml
+++ b/kobuki_ws/docker/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
       cache_from:
         - j3soon/ros2-kobuki-ws:buildcache-amd64
         - j3soon/ros2-kobuki-ws:buildcache-arm64

--- a/kobuki_ws/docker/compose.yaml
+++ b/kobuki_ws/docker/compose.yaml
@@ -23,7 +23,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
       cache_from:
         - j3soon/ros2-kobuki-ws:buildcache-amd64
         - j3soon/ros2-kobuki-ws:buildcache-arm64

--- a/kobuki_ws/docker/compose.yaml
+++ b/kobuki_ws/docker/compose.yaml
@@ -21,6 +21,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
       cache_from:
         - j3soon/ros2-kobuki-ws:buildcache-amd64
         - j3soon/ros2-kobuki-ws:buildcache-arm64

--- a/orbslam3_ws/.gitignore
+++ b/orbslam3_ws/.gitignore
@@ -8,6 +8,7 @@
 
 # Soft Links
 /docs
+/docker/modules
 
 # ROS2 bag files
 V1_02_medium.bag

--- a/orbslam3_ws/docker/.bashrc
+++ b/orbslam3_ws/docker/.bashrc
@@ -7,6 +7,23 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
+echo "changing ownership of Isaac Sim user cache directories..."
+sudo chown user:user /isaac-sim
+sudo chown user:user /isaac-sim/kit
+sudo chown user:user /isaac-sim/kit/cache
+sudo chown user:user /home/user/.cache
+sudo chown user:user /home/user/.cache/ov
+sudo chown user:user /home/user/.cache/pip
+sudo chown user:user /home/user/.cache/nvidia
+sudo chown user:user /home/user/.cache/nvidia/GLCache
+sudo chown user:user /home/user/.nv
+sudo chown user:user /home/user/.nv/ComputeCache
+sudo chown user:user /home/user/.nvidia-omniverse
+sudo chown user:user /home/user/.nvidia-omniverse/logs
+sudo chown user:user /home/user/.local/share/ov
+sudo chown user:user /home/user/.local/share/ov/data
+sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/orbslam3_ws/docker/.dockerignore
+++ b/orbslam3_ws/docker/.dockerignore
@@ -1,2 +1,3 @@
 *
 !.bashrc
+!modules

--- a/orbslam3_ws/docker/Dockerfile
+++ b/orbslam3_ws/docker/Dockerfile
@@ -47,71 +47,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GUI debugging tools
-# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
-#   Ref: https://packages.debian.org/sid/x11-apps
-#   Ref: https://packages.debian.org/sid/x11-utils
-# - `mesa-utils` for `glxgears` and `glxinfo`
-#   Ref: https://wiki.debian.org/Mesa
-# - `vulkan-tools` for `vkcube` and `vulkaninfo`
-#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
-#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get update && apt-get install -y \
-    x11-apps x11-utils \
-    mesa-utils \
-    libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Install Vulkan config files
-# Ref: https://gitlab.com/nvidia/container-images/vulkan
-# Ref: https://github.com/j3soon/docker-vulkan-runtime
-RUN cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194"
-    }
-}
-EOF
-RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
-    cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libEGL_nvidia.so.0"
-    }
-}
-EOF
-RUN cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "layer": {
-        "name": "VK_LAYER_NV_optimus",
-        "type": "INSTANCE",
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194",
-        "implementation_version" : "1",
-        "description" : "NVIDIA Optimus layer",
-        "functions": {
-            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
-            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
-        },
-        "enable_environment": {
-            "__NV_PRIME_RENDER_OFFLOAD": "1"
-        },
-        "disable_environment": {
-            "DISABLE_LAYER_NV_OPTIMUS_1": ""
-        }
-    }
-}
-EOF
+# Install GUI debugging tools and configure Vulkan
+COPY --chown=root:root modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
 # Install ROS2 Gazebo packages for amd64
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -145,44 +89,14 @@ USER $USERNAME
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
-# Install `libxrandr2` to support Isaac Sim WebRTC streaming
+# Isaac Sim version configuration
+ARG ISAAC_SIM_VERSION=4.2.0.2
+# Copy and run Isaac Sim installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo apt-get update && sudo apt-get install -y \
-        libxrandr2 \
-        && sudo rm -rf /var/lib/apt/lists/*; \
-    fi
-# Install Isaac Sim (requires Python 3.10)
-# Note that installing Isaac Sim with pip is experimental, keep this in mind when unexpected error occurs
-# TODO: Remove the note above when it is no longer experimental
-# Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
-RUN --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        python3 -V | grep "Python 3.10" \
-        && pip install isaacsim==4.2.0.2 --extra-index-url https://pypi.nvidia.com \
-        && pip install isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com; \
-    fi
-
-# Fix SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) `numpy==1.26.0`, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        pip install scipy==1.14.1 numpy==1.26.0; \
-    fi
-
-# Create isaac sim cache directory with correct ownership to avoid permission issues after volume mount, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo mkdir -p /isaac-sim/kit/cache \
-        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache; \
-    fi
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        mkdir -p /home/$USERNAME/.cache/ov \
-        && mkdir -p /home/$USERNAME/.cache/pip \
-        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-        && mkdir -p /home/$USERNAME/.local/share/ov/data \
-        && mkdir -p /home/$USERNAME/Documents; \
-    fi
-
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53

--- a/orbslam3_ws/docker/Dockerfile
+++ b/orbslam3_ws/docker/Dockerfile
@@ -90,7 +90,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.5.0.0
+ARG ISAAC_SIM_VERSION=4.5.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/orbslam3_ws/docker/Dockerfile
+++ b/orbslam3_ws/docker/Dockerfile
@@ -90,7 +90,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.2.0.2
+ARG ISAAC_SIM_VERSION=4.5.0.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/orbslam3_ws/docker/Dockerfile
+++ b/orbslam3_ws/docker/Dockerfile
@@ -104,6 +104,17 @@ ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
 
+# Set TERM to prevent Isaac Lab error during docker build:
+#    'ansi+tabs': unknown terminal type.
+ENV TERM=xterm-256color
+# Isaac Lab version configuration
+ARG ISAAC_LAB_VERSION=2.1.0
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     sudo apt-get update && sudo apt-get install -y \

--- a/orbslam3_ws/docker/compose.yaml
+++ b/orbslam3_ws/docker/compose.yaml
@@ -23,7 +23,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
       cache_from:
         - j3soon/ros2-orbslam3-ws:buildcache-amd64
         - j3soon/ros2-orbslam3-ws:buildcache-arm64

--- a/orbslam3_ws/docker/compose.yaml
+++ b/orbslam3_ws/docker/compose.yaml
@@ -21,6 +21,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
       cache_from:
         - j3soon/ros2-orbslam3-ws:buildcache-amd64
         - j3soon/ros2-orbslam3-ws:buildcache-arm64

--- a/orbslam3_ws/docker/compose.yaml
+++ b/orbslam3_ws/docker/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
       cache_from:
         - j3soon/ros2-orbslam3-ws:buildcache-amd64
         - j3soon/ros2-orbslam3-ws:buildcache-arm64

--- a/orbslam3_ws/docker/compose.yaml
+++ b/orbslam3_ws/docker/compose.yaml
@@ -23,6 +23,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
       cache_from:
         - j3soon/ros2-orbslam3-ws:buildcache-amd64
         - j3soon/ros2-orbslam3-ws:buildcache-arm64

--- a/orbslam3_ws/docker/compose.yaml
+++ b/orbslam3_ws/docker/compose.yaml
@@ -7,8 +7,7 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        mkdir -p /isaac-sim/standalone/{logs,data}"
     volumes:
       - isaac-sim-cache:/isaac-sim
   orbslam3-ws:

--- a/ros1_bridge_ws/.gitignore
+++ b/ros1_bridge_ws/.gitignore
@@ -8,3 +8,4 @@
 
 # Soft Links
 /docs
+/docker/modules

--- a/ros1_bridge_ws/docker/.dockerignore
+++ b/ros1_bridge_ws/docker/.dockerignore
@@ -1,3 +1,5 @@
 *
+!.bashrc
+!modules
 !start-bridge.sh
 !.env

--- a/ros1_bridge_ws/docker/compose.yaml
+++ b/ros1_bridge_ws/docker/compose.yaml
@@ -25,6 +25,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
     image: j3soon/ros2-ros1-bridge-ws
     container_name: ros2-ros1-bridge-ws
     depends_on:

--- a/ros1_bridge_ws/docker/compose.yaml
+++ b/ros1_bridge_ws/docker/compose.yaml
@@ -22,6 +22,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
     image: j3soon/ros2-ros1-bridge-ws
     container_name: ros2-ros1-bridge-ws
     depends_on:

--- a/ros1_bridge_ws/docker/compose.yaml
+++ b/ros1_bridge_ws/docker/compose.yaml
@@ -24,7 +24,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
     image: j3soon/ros2-ros1-bridge-ws
     container_name: ros2-ros1-bridge-ws
     depends_on:

--- a/ros1_bridge_ws/docker/compose.yaml
+++ b/ros1_bridge_ws/docker/compose.yaml
@@ -24,7 +24,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
     image: j3soon/ros2-ros1-bridge-ws
     container_name: ros2-ros1-bridge-ws
     depends_on:

--- a/rtabmap_ws/.gitignore
+++ b/rtabmap_ws/.gitignore
@@ -8,3 +8,4 @@
 
 # Soft Links
 /docs
+/docker/modules

--- a/rtabmap_ws/docker/.bashrc
+++ b/rtabmap_ws/docker/.bashrc
@@ -7,6 +7,23 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
+echo "changing ownership of Isaac Sim user cache directories..."
+sudo chown user:user /isaac-sim
+sudo chown user:user /isaac-sim/kit
+sudo chown user:user /isaac-sim/kit/cache
+sudo chown user:user /home/user/.cache
+sudo chown user:user /home/user/.cache/ov
+sudo chown user:user /home/user/.cache/pip
+sudo chown user:user /home/user/.cache/nvidia
+sudo chown user:user /home/user/.cache/nvidia/GLCache
+sudo chown user:user /home/user/.nv
+sudo chown user:user /home/user/.nv/ComputeCache
+sudo chown user:user /home/user/.nvidia-omniverse
+sudo chown user:user /home/user/.nvidia-omniverse/logs
+sudo chown user:user /home/user/.local/share/ov
+sudo chown user:user /home/user/.local/share/ov/data
+sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/rtabmap_ws/docker/.dockerignore
+++ b/rtabmap_ws/docker/.dockerignore
@@ -1,2 +1,3 @@
 *
 !.bashrc
+!modules

--- a/rtabmap_ws/docker/Dockerfile
+++ b/rtabmap_ws/docker/Dockerfile
@@ -107,6 +107,17 @@ ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
 
+# Set TERM to prevent Isaac Lab error during docker build:
+#    'ansi+tabs': unknown terminal type.
+ENV TERM=xterm-256color
+# Isaac Lab version configuration
+ARG ISAAC_LAB_VERSION=2.1.0
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     sudo apt-get update && sudo apt-get install -y \

--- a/rtabmap_ws/docker/Dockerfile
+++ b/rtabmap_ws/docker/Dockerfile
@@ -93,7 +93,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.5.0.0
+ARG ISAAC_SIM_VERSION=4.5.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/rtabmap_ws/docker/Dockerfile
+++ b/rtabmap_ws/docker/Dockerfile
@@ -93,7 +93,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.2.0.2
+ARG ISAAC_SIM_VERSION=4.5.0.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/rtabmap_ws/docker/Dockerfile
+++ b/rtabmap_ws/docker/Dockerfile
@@ -50,71 +50,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GUI debugging tools
-# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
-#   Ref: https://packages.debian.org/sid/x11-apps
-#   Ref: https://packages.debian.org/sid/x11-utils
-# - `mesa-utils` for `glxgears` and `glxinfo`
-#   Ref: https://wiki.debian.org/Mesa
-# - `vulkan-tools` for `vkcube` and `vulkaninfo`
-#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
-#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get update && apt-get install -y \
-    x11-apps x11-utils \
-    mesa-utils \
-    libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Install Vulkan config files
-# Ref: https://gitlab.com/nvidia/container-images/vulkan
-# Ref: https://github.com/j3soon/docker-vulkan-runtime
-RUN cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194"
-    }
-}
-EOF
-RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
-    cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libEGL_nvidia.so.0"
-    }
-}
-EOF
-RUN cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "layer": {
-        "name": "VK_LAYER_NV_optimus",
-        "type": "INSTANCE",
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194",
-        "implementation_version" : "1",
-        "description" : "NVIDIA Optimus layer",
-        "functions": {
-            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
-            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
-        },
-        "enable_environment": {
-            "__NV_PRIME_RENDER_OFFLOAD": "1"
-        },
-        "disable_environment": {
-            "DISABLE_LAYER_NV_OPTIMUS_1": ""
-        }
-    }
-}
-EOF
+# Install GUI debugging tools and configure Vulkan
+COPY --chown=root:root modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
 # Install ROS2 Gazebo packages for amd64
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -148,44 +92,14 @@ USER $USERNAME
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
-# Install `libxrandr2` to support Isaac Sim WebRTC streaming
+# Isaac Sim version configuration
+ARG ISAAC_SIM_VERSION=4.2.0.2
+# Copy and run Isaac Sim installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo apt-get update && sudo apt-get install -y \
-        libxrandr2 \
-        && sudo rm -rf /var/lib/apt/lists/*; \
-    fi
-# Install Isaac Sim (requires Python 3.10)
-# Note that installing Isaac Sim with pip is experimental, keep this in mind when unexpected error occurs
-# TODO: Remove the note above when it is no longer experimental
-# Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
-RUN --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        python3 -V | grep "Python 3.10" \
-        && pip install isaacsim==4.2.0.2 --extra-index-url https://pypi.nvidia.com \
-        && pip install isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com; \
-    fi
-
-# Fix SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) `numpy==1.26.0`, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        pip install scipy==1.14.1 numpy==1.26.0; \
-    fi
-
-# Create isaac sim cache directory with correct ownership to avoid permission issues after volume mount, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo mkdir -p /isaac-sim/kit/cache \
-        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache; \
-    fi
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        mkdir -p /home/$USERNAME/.cache/ov \
-        && mkdir -p /home/$USERNAME/.cache/pip \
-        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-        && mkdir -p /home/$USERNAME/.local/share/ov/data \
-        && mkdir -p /home/$USERNAME/Documents; \
-    fi
-
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53

--- a/rtabmap_ws/docker/compose.yaml
+++ b/rtabmap_ws/docker/compose.yaml
@@ -23,6 +23,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
       cache_from:
         - j3soon/ros2-rtabmap-ws:buildcache-amd64
         - j3soon/ros2-rtabmap-ws:buildcache-arm64

--- a/rtabmap_ws/docker/compose.yaml
+++ b/rtabmap_ws/docker/compose.yaml
@@ -7,8 +7,7 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        mkdir -p /isaac-sim/standalone/{logs,data}"
     volumes:
       - isaac-sim-cache:/isaac-sim
   rtabmap-ws:

--- a/rtabmap_ws/docker/compose.yaml
+++ b/rtabmap_ws/docker/compose.yaml
@@ -21,6 +21,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
       cache_from:
         - j3soon/ros2-rtabmap-ws:buildcache-amd64
         - j3soon/ros2-rtabmap-ws:buildcache-arm64

--- a/rtabmap_ws/docker/compose.yaml
+++ b/rtabmap_ws/docker/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
       cache_from:
         - j3soon/ros2-rtabmap-ws:buildcache-amd64
         - j3soon/ros2-rtabmap-ws:buildcache-arm64

--- a/rtabmap_ws/docker/compose.yaml
+++ b/rtabmap_ws/docker/compose.yaml
@@ -23,7 +23,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
       cache_from:
         - j3soon/ros2-rtabmap-ws:buildcache-amd64
         - j3soon/ros2-rtabmap-ws:buildcache-arm64

--- a/scripts/post_install.sh
+++ b/scripts/post_install.sh
@@ -4,9 +4,10 @@
 # Reference: https://stackoverflow.com/q/59895
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 
-cd "$SCRIPT_DIR/.."
+cd "$SCRIPT_DIR"
 
-rm _isaac_sim 2>/dev/null || true
-ln -s ~/.local/share/ov/pkg/isaac-sim-4.2.0 _isaac_sim
+./setup_docker_modules_link.sh
+./setup_docs_link.sh
+./setup_isaac_link.sh
 
-echo "Set up Isaac link done."
+echo "Post Install Done."

--- a/scripts/pull_amd64_docker_images.sh
+++ b/scripts/pull_amd64_docker_images.sh
@@ -19,6 +19,8 @@ images=(
     "j3soon/ros2-vlp-ws"
     "j3soon/ros2-gazebo-world-ws"
     "j3soon/ros2-aloha-ws"
+    "j3soon/ros2-turtlebot3-ws"
+    "j3soon/ros2-delto-gripper-ws"
 )
 
 # Loop through each image and pull it

--- a/scripts/setup_docker_modules_link.sh
+++ b/scripts/setup_docker_modules_link.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+# Get the directory of this script.
+# Reference: https://stackoverflow.com/q/59895
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+
+cd "$SCRIPT_DIR/.."
+
+workspaces=( *_ws* )
+
+# Loop through each workspace and link docker modules
+for ws in "${workspaces[@]}"
+do
+    mkdir -p "${ws}/docker/modules"
+    rm -f "${ws}/docker/modules"/* 2>/dev/null || true
+    for file in docker_modules/*; do
+        if [ -f "$file" ]; then
+            ln "$file" "${ws}/docker/modules/"
+        fi
+    done
+done
+
+echo "Set up docker modules link done."

--- a/scripts/setup_docs_link.sh
+++ b/scripts/setup_docs_link.sh
@@ -16,8 +16,8 @@ ln "${PWD}/README.md" docs/index.md
 for ws in "${workspaces[@]}"
 do
     ws_hyphen="$(echo $ws | sed "s/_/-/g")"
-    rm "${ws}/docs" || true
+    rm "${ws}/docs" 2>/dev/null || true
     ln -s "${PWD}/docs/${ws_hyphen}" "${ws}/docs"
 done
 
-echo "Done."
+echo "Set up docs link done."

--- a/scripts/setup_isaac_link.sh
+++ b/scripts/setup_isaac_link.sh
@@ -7,6 +7,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 cd "$SCRIPT_DIR/.."
 
 rm _isaac_sim 2>/dev/null || true
-ln -s ~/.local/share/ov/pkg/isaac-sim-4.2.0 _isaac_sim
+ln -s ~/isaacsim _isaac_sim
 
 echo "Set up Isaac link done."

--- a/template_ws/.gitignore
+++ b/template_ws/.gitignore
@@ -8,3 +8,4 @@
 
 # Soft Links
 /docs
+/docker/modules

--- a/template_ws/docker/.bashrc
+++ b/template_ws/docker/.bashrc
@@ -7,6 +7,23 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
+echo "changing ownership of Isaac Sim user cache directories..."
+sudo chown user:user /isaac-sim
+sudo chown user:user /isaac-sim/kit
+sudo chown user:user /isaac-sim/kit/cache
+sudo chown user:user /home/user/.cache
+sudo chown user:user /home/user/.cache/ov
+sudo chown user:user /home/user/.cache/pip
+sudo chown user:user /home/user/.cache/nvidia
+sudo chown user:user /home/user/.cache/nvidia/GLCache
+sudo chown user:user /home/user/.nv
+sudo chown user:user /home/user/.nv/ComputeCache
+sudo chown user:user /home/user/.nvidia-omniverse
+sudo chown user:user /home/user/.nvidia-omniverse/logs
+sudo chown user:user /home/user/.local/share/ov
+sudo chown user:user /home/user/.local/share/ov/data
+sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/template_ws/docker/.dockerignore
+++ b/template_ws/docker/.dockerignore
@@ -1,2 +1,3 @@
 *
 !.bashrc
+!modules

--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -88,7 +88,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.5.0.0
+ARG ISAAC_SIM_VERSION=4.5.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -88,7 +88,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.2.0.2
+ARG ISAAC_SIM_VERSION=4.5.0.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -45,71 +45,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GUI debugging tools
-# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
-#   Ref: https://packages.debian.org/sid/x11-apps
-#   Ref: https://packages.debian.org/sid/x11-utils
-# - `mesa-utils` for `glxgears` and `glxinfo`
-#   Ref: https://wiki.debian.org/Mesa
-# - `vulkan-tools` for `vkcube` and `vulkaninfo`
-#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
-#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get update && apt-get install -y \
-    x11-apps x11-utils \
-    mesa-utils \
-    libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Install Vulkan config files
-# Ref: https://gitlab.com/nvidia/container-images/vulkan
-# Ref: https://github.com/j3soon/docker-vulkan-runtime
-RUN cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194"
-    }
-}
-EOF
-RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
-    cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libEGL_nvidia.so.0"
-    }
-}
-EOF
-RUN cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "layer": {
-        "name": "VK_LAYER_NV_optimus",
-        "type": "INSTANCE",
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194",
-        "implementation_version" : "1",
-        "description" : "NVIDIA Optimus layer",
-        "functions": {
-            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
-            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
-        },
-        "enable_environment": {
-            "__NV_PRIME_RENDER_OFFLOAD": "1"
-        },
-        "disable_environment": {
-            "DISABLE_LAYER_NV_OPTIMUS_1": ""
-        }
-    }
-}
-EOF
+# Install GUI debugging tools and configure Vulkan
+COPY --chown=root:root modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
 # Install ROS2 Gazebo packages for amd64
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -143,44 +87,14 @@ USER $USERNAME
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
-# Install `libxrandr2` to support Isaac Sim WebRTC streaming
+# Isaac Sim version configuration
+ARG ISAAC_SIM_VERSION=4.2.0.2
+# Copy and run Isaac Sim installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo apt-get update && sudo apt-get install -y \
-        libxrandr2 \
-        && sudo rm -rf /var/lib/apt/lists/*; \
-    fi
-# Install Isaac Sim (requires Python 3.10)
-# Note that installing Isaac Sim with pip is experimental, keep this in mind when unexpected error occurs
-# TODO: Remove the note above when it is no longer experimental
-# Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
-RUN --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        python3 -V | grep "Python 3.10" \
-        && pip install isaacsim==4.2.0.2 --extra-index-url https://pypi.nvidia.com \
-        && pip install isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com; \
-    fi
-
-# Fix SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) `numpy==1.26.0`, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        pip install scipy==1.14.1 numpy==1.26.0; \
-    fi
-
-# Create isaac sim cache directory with correct ownership to avoid permission issues after volume mount, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo mkdir -p /isaac-sim/kit/cache \
-        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache; \
-    fi
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        mkdir -p /home/$USERNAME/.cache/ov \
-        && mkdir -p /home/$USERNAME/.cache/pip \
-        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-        && mkdir -p /home/$USERNAME/.local/share/ov/data \
-        && mkdir -p /home/$USERNAME/Documents; \
-    fi
-
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53

--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -102,6 +102,17 @@ ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
 
+# Set TERM to prevent Isaac Lab error during docker build:
+#    'ansi+tabs': unknown terminal type.
+ENV TERM=xterm-256color
+# Isaac Lab version configuration
+ARG ISAAC_LAB_VERSION=2.1.0
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     sudo apt-get update && sudo apt-get install -y \

--- a/template_ws/docker/compose.yaml
+++ b/template_ws/docker/compose.yaml
@@ -23,7 +23,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
       cache_from:
         - j3soon/ros2-template-ws:buildcache-amd64
         - j3soon/ros2-template-ws:buildcache-arm64

--- a/template_ws/docker/compose.yaml
+++ b/template_ws/docker/compose.yaml
@@ -7,8 +7,7 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        mkdir -p /isaac-sim/standalone/{logs,data}"
     volumes:
       - isaac-sim-cache:/isaac-sim
   template-ws:

--- a/template_ws/docker/compose.yaml
+++ b/template_ws/docker/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
       cache_from:
         - j3soon/ros2-template-ws:buildcache-amd64
         - j3soon/ros2-template-ws:buildcache-arm64

--- a/template_ws/docker/compose.yaml
+++ b/template_ws/docker/compose.yaml
@@ -21,6 +21,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
       cache_from:
         - j3soon/ros2-template-ws:buildcache-amd64
         - j3soon/ros2-template-ws:buildcache-arm64

--- a/template_ws/docker/compose.yaml
+++ b/template_ws/docker/compose.yaml
@@ -23,6 +23,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
       cache_from:
         - j3soon/ros2-template-ws:buildcache-amd64
         - j3soon/ros2-template-ws:buildcache-arm64

--- a/tests/diff_base/docker/.bashrc
+++ b/tests/diff_base/docker/.bashrc
@@ -8,6 +8,23 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
+echo "changing ownership of Isaac Sim user cache directories..."
+sudo chown user:user /isaac-sim
+sudo chown user:user /isaac-sim/kit
+sudo chown user:user /isaac-sim/kit/cache
+sudo chown user:user /home/user/.cache
+sudo chown user:user /home/user/.cache/ov
+sudo chown user:user /home/user/.cache/pip
+sudo chown user:user /home/user/.cache/nvidia
+sudo chown user:user /home/user/.cache/nvidia/GLCache
+sudo chown user:user /home/user/.nv
+sudo chown user:user /home/user/.nv/ComputeCache
+sudo chown user:user /home/user/.nvidia-omniverse
+sudo chown user:user /home/user/.nvidia-omniverse/logs
+sudo chown user:user /home/user/.local/share/ov
+sudo chown user:user /home/user/.local/share/ov/data
+sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/tests/diff_base/docker/Dockerfile
+++ b/tests/diff_base/docker/Dockerfile
@@ -103,6 +103,17 @@ ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
 
+# Set TERM to prevent Isaac Lab error during docker build:
+#    'ansi+tabs': unknown terminal type.
+ENV TERM=xterm-256color
+# Isaac Lab version configuration
+ARG ISAAC_LAB_VERSION=2.1.0
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     sudo apt-get update && sudo apt-get install -y \

--- a/tests/diff_base/docker/Dockerfile
+++ b/tests/diff_base/docker/Dockerfile
@@ -89,7 +89,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.5.0.0
+ARG ISAAC_SIM_VERSION=4.5.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/tests/diff_base/docker/Dockerfile
+++ b/tests/diff_base/docker/Dockerfile
@@ -46,71 +46,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GUI debugging tools
-# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
-#   Ref: https://packages.debian.org/sid/x11-apps
-#   Ref: https://packages.debian.org/sid/x11-utils
-# - `mesa-utils` for `glxgears` and `glxinfo`
-#   Ref: https://wiki.debian.org/Mesa
-# - `vulkan-tools` for `vkcube` and `vulkaninfo`
-#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
-#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get update && apt-get install -y \
-    x11-apps x11-utils \
-    mesa-utils \
-    libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Install Vulkan config files
-# Ref: https://gitlab.com/nvidia/container-images/vulkan
-# Ref: https://github.com/j3soon/docker-vulkan-runtime
-RUN cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194"
-    }
-}
-EOF
-RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
-    cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libEGL_nvidia.so.0"
-    }
-}
-EOF
-RUN cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "layer": {
-        "name": "VK_LAYER_NV_optimus",
-        "type": "INSTANCE",
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194",
-        "implementation_version" : "1",
-        "description" : "NVIDIA Optimus layer",
-        "functions": {
-            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
-            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
-        },
-        "enable_environment": {
-            "__NV_PRIME_RENDER_OFFLOAD": "1"
-        },
-        "disable_environment": {
-            "DISABLE_LAYER_NV_OPTIMUS_1": ""
-        }
-    }
-}
-EOF
+# Install GUI debugging tools and configure Vulkan
+COPY --chown=root:root modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
 # Install ROS2 Gazebo packages for amd64
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -144,44 +88,14 @@ USER $USERNAME
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
-# Install `libxrandr2` to support Isaac Sim WebRTC streaming
+# Isaac Sim version configuration
+ARG ISAAC_SIM_VERSION=4.2.0.2
+# Copy and run Isaac Sim installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo apt-get update && sudo apt-get install -y \
-        libxrandr2 \
-        && sudo rm -rf /var/lib/apt/lists/*; \
-    fi
-# Install Isaac Sim (requires Python 3.10)
-# Note that installing Isaac Sim with pip is experimental, keep this in mind when unexpected error occurs
-# TODO: Remove the note above when it is no longer experimental
-# Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
-RUN --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        python3 -V | grep "Python 3.10" \
-        && pip install isaacsim==4.2.0.2 --extra-index-url https://pypi.nvidia.com \
-        && pip install isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com; \
-    fi
-
-# Fix SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) `numpy==1.26.0`, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        pip install scipy==1.14.1 numpy==1.26.0; \
-    fi
-
-# Create isaac sim cache directory with correct ownership to avoid permission issues after volume mount, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo mkdir -p /isaac-sim/kit/cache \
-        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache; \
-    fi
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        mkdir -p /home/$USERNAME/.cache/ov \
-        && mkdir -p /home/$USERNAME/.cache/pip \
-        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-        && mkdir -p /home/$USERNAME/.local/share/ov/data \
-        && mkdir -p /home/$USERNAME/Documents; \
-    fi
-
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53

--- a/tests/diff_base/docker/Dockerfile
+++ b/tests/diff_base/docker/Dockerfile
@@ -89,7 +89,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.2.0.2
+ARG ISAAC_SIM_VERSION=4.5.0.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/tests/diff_base/docker/compose.yaml
+++ b/tests/diff_base/docker/compose.yaml
@@ -21,6 +21,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
       cache_from:
         - j3soon/ros2-{PLACEHOLDER}-ws:buildcache-amd64
         - j3soon/ros2-{PLACEHOLDER}-ws:buildcache-arm64

--- a/tests/diff_base/docker/compose.yaml
+++ b/tests/diff_base/docker/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
       cache_from:
         - j3soon/ros2-{PLACEHOLDER}-ws:buildcache-amd64
         - j3soon/ros2-{PLACEHOLDER}-ws:buildcache-arm64

--- a/tests/diff_base/docker/compose.yaml
+++ b/tests/diff_base/docker/compose.yaml
@@ -23,7 +23,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
       cache_from:
         - j3soon/ros2-{PLACEHOLDER}-ws:buildcache-amd64
         - j3soon/ros2-{PLACEHOLDER}-ws:buildcache-arm64

--- a/tests/diff_base/docker/compose.yaml
+++ b/tests/diff_base/docker/compose.yaml
@@ -7,8 +7,7 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        mkdir -p /isaac-sim/standalone/{logs,data}"
     volumes:
       - isaac-sim-cache:/isaac-sim
   {PLACEHOLDER}-ws:

--- a/tests/diff_base/docker/compose.yaml
+++ b/tests/diff_base/docker/compose.yaml
@@ -23,6 +23,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
       cache_from:
         - j3soon/ros2-{PLACEHOLDER}-ws:buildcache-amd64
         - j3soon/ros2-{PLACEHOLDER}-ws:buildcache-arm64

--- a/turtlebot3_ws/.gitignore
+++ b/turtlebot3_ws/.gitignore
@@ -8,6 +8,7 @@
 
 # Soft Links
 /docs
+/docker/modules
 
 # Custom ignores
 /isaacsim/assets

--- a/turtlebot3_ws/docker/.bashrc
+++ b/turtlebot3_ws/docker/.bashrc
@@ -7,6 +7,23 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
+echo "changing ownership of Isaac Sim user cache directories..."
+sudo chown user:user /isaac-sim
+sudo chown user:user /isaac-sim/kit
+sudo chown user:user /isaac-sim/kit/cache
+sudo chown user:user /home/user/.cache
+sudo chown user:user /home/user/.cache/ov
+sudo chown user:user /home/user/.cache/pip
+sudo chown user:user /home/user/.cache/nvidia
+sudo chown user:user /home/user/.cache/nvidia/GLCache
+sudo chown user:user /home/user/.nv
+sudo chown user:user /home/user/.nv/ComputeCache
+sudo chown user:user /home/user/.nvidia-omniverse
+sudo chown user:user /home/user/.nvidia-omniverse/logs
+sudo chown user:user /home/user/.local/share/ov
+sudo chown user:user /home/user/.local/share/ov/data
+sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/turtlebot3_ws/docker/.dockerignore
+++ b/turtlebot3_ws/docker/.dockerignore
@@ -1,2 +1,3 @@
 *
 !.bashrc
+!modules

--- a/turtlebot3_ws/docker/Dockerfile
+++ b/turtlebot3_ws/docker/Dockerfile
@@ -88,7 +88,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.5.0.0
+ARG ISAAC_SIM_VERSION=4.5.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/turtlebot3_ws/docker/Dockerfile
+++ b/turtlebot3_ws/docker/Dockerfile
@@ -88,7 +88,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.2.0.2
+ARG ISAAC_SIM_VERSION=4.5.0.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/turtlebot3_ws/docker/Dockerfile
+++ b/turtlebot3_ws/docker/Dockerfile
@@ -45,71 +45,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GUI debugging tools
-# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
-#   Ref: https://packages.debian.org/sid/x11-apps
-#   Ref: https://packages.debian.org/sid/x11-utils
-# - `mesa-utils` for `glxgears` and `glxinfo`
-#   Ref: https://wiki.debian.org/Mesa
-# - `vulkan-tools` for `vkcube` and `vulkaninfo`
-#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
-#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get update && apt-get install -y \
-    x11-apps x11-utils \
-    mesa-utils \
-    libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Install Vulkan config files
-# Ref: https://gitlab.com/nvidia/container-images/vulkan
-# Ref: https://github.com/j3soon/docker-vulkan-runtime
-RUN cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194"
-    }
-}
-EOF
-RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
-    cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libEGL_nvidia.so.0"
-    }
-}
-EOF
-RUN cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "layer": {
-        "name": "VK_LAYER_NV_optimus",
-        "type": "INSTANCE",
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194",
-        "implementation_version" : "1",
-        "description" : "NVIDIA Optimus layer",
-        "functions": {
-            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
-            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
-        },
-        "enable_environment": {
-            "__NV_PRIME_RENDER_OFFLOAD": "1"
-        },
-        "disable_environment": {
-            "DISABLE_LAYER_NV_OPTIMUS_1": ""
-        }
-    }
-}
-EOF
+# Install GUI debugging tools and configure Vulkan
+COPY --chown=root:root modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
 # Install ROS2 Gazebo packages for amd64
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -143,44 +87,14 @@ USER $USERNAME
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
-# Install `libxrandr2` to support Isaac Sim WebRTC streaming
+# Isaac Sim version configuration
+ARG ISAAC_SIM_VERSION=4.2.0.2
+# Copy and run Isaac Sim installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo apt-get update && sudo apt-get install -y \
-        libxrandr2 \
-        && sudo rm -rf /var/lib/apt/lists/*; \
-    fi
-# Install Isaac Sim (requires Python 3.10)
-# Note that installing Isaac Sim with pip is experimental, keep this in mind when unexpected error occurs
-# TODO: Remove the note above when it is no longer experimental
-# Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
-RUN --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        python3 -V | grep "Python 3.10" \
-        && pip install isaacsim==4.2.0.2 --extra-index-url https://pypi.nvidia.com \
-        && pip install isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com; \
-    fi
-
-# Fix SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) `numpy==1.26.0`, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        pip install scipy==1.14.1 numpy==1.26.0; \
-    fi
-
-# Create isaac sim cache directory with correct ownership to avoid permission issues after volume mount, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo mkdir -p /isaac-sim/kit/cache \
-        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache; \
-    fi
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        mkdir -p /home/$USERNAME/.cache/ov \
-        && mkdir -p /home/$USERNAME/.cache/pip \
-        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-        && mkdir -p /home/$USERNAME/.local/share/ov/data \
-        && mkdir -p /home/$USERNAME/Documents; \
-    fi
-
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53

--- a/turtlebot3_ws/docker/Dockerfile
+++ b/turtlebot3_ws/docker/Dockerfile
@@ -102,6 +102,17 @@ ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
 
+# Set TERM to prevent Isaac Lab error during docker build:
+#    'ansi+tabs': unknown terminal type.
+ENV TERM=xterm-256color
+# Isaac Lab version configuration
+ARG ISAAC_LAB_VERSION=2.1.0
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     sudo apt-get update && sudo apt-get install -y \

--- a/turtlebot3_ws/docker/compose.yaml
+++ b/turtlebot3_ws/docker/compose.yaml
@@ -7,8 +7,7 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        mkdir -p /isaac-sim/standalone/{logs,data}"
     volumes:
       - isaac-sim-cache:/isaac-sim
   turtlebot3-ws:

--- a/turtlebot3_ws/docker/compose.yaml
+++ b/turtlebot3_ws/docker/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
       cache_from:
         - j3soon/ros2-turtlebot3-ws:buildcache-amd64
         - j3soon/ros2-turtlebot3-ws:buildcache-arm64

--- a/turtlebot3_ws/docker/compose.yaml
+++ b/turtlebot3_ws/docker/compose.yaml
@@ -23,7 +23,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
       cache_from:
         - j3soon/ros2-turtlebot3-ws:buildcache-amd64
         - j3soon/ros2-turtlebot3-ws:buildcache-arm64

--- a/turtlebot3_ws/docker/compose.yaml
+++ b/turtlebot3_ws/docker/compose.yaml
@@ -23,6 +23,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
       cache_from:
         - j3soon/ros2-turtlebot3-ws:buildcache-amd64
         - j3soon/ros2-turtlebot3-ws:buildcache-arm64

--- a/turtlebot3_ws/docker/compose.yaml
+++ b/turtlebot3_ws/docker/compose.yaml
@@ -21,6 +21,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
       cache_from:
         - j3soon/ros2-turtlebot3-ws:buildcache-amd64
         - j3soon/ros2-turtlebot3-ws:buildcache-arm64

--- a/vlp_ws/.gitignore
+++ b/vlp_ws/.gitignore
@@ -8,3 +8,4 @@
 
 # Soft Links
 /docs
+/docker/modules

--- a/vlp_ws/docker/.bashrc
+++ b/vlp_ws/docker/.bashrc
@@ -7,6 +7,23 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
+echo "changing ownership of Isaac Sim user cache directories..."
+sudo chown user:user /isaac-sim
+sudo chown user:user /isaac-sim/kit
+sudo chown user:user /isaac-sim/kit/cache
+sudo chown user:user /home/user/.cache
+sudo chown user:user /home/user/.cache/ov
+sudo chown user:user /home/user/.cache/pip
+sudo chown user:user /home/user/.cache/nvidia
+sudo chown user:user /home/user/.cache/nvidia/GLCache
+sudo chown user:user /home/user/.nv
+sudo chown user:user /home/user/.nv/ComputeCache
+sudo chown user:user /home/user/.nvidia-omniverse
+sudo chown user:user /home/user/.nvidia-omniverse/logs
+sudo chown user:user /home/user/.local/share/ov
+sudo chown user:user /home/user/.local/share/ov/data
+sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/vlp_ws/docker/.dockerignore
+++ b/vlp_ws/docker/.dockerignore
@@ -1,2 +1,3 @@
 *
 !.bashrc
+!modules

--- a/vlp_ws/docker/Dockerfile
+++ b/vlp_ws/docker/Dockerfile
@@ -47,71 +47,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GUI debugging tools
-# - `x11-apps` and `x11-utils` for `xeyes` and `xdpyinfo`
-#   Ref: https://packages.debian.org/sid/x11-apps
-#   Ref: https://packages.debian.org/sid/x11-utils
-# - `mesa-utils` for `glxgears` and `glxinfo`
-#   Ref: https://wiki.debian.org/Mesa
-# - `vulkan-tools` for `vkcube` and `vulkaninfo`
-#   Ref: https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_vulkan_packages
-#   Ref: https://gitlab.com/nvidia/container-images/vulkan/-/blob/master/docker/Dockerfile.ubuntu
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get update && apt-get install -y \
-    x11-apps x11-utils \
-    mesa-utils \
-    libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-# Install Vulkan config files
-# Ref: https://gitlab.com/nvidia/container-images/vulkan
-# Ref: https://github.com/j3soon/docker-vulkan-runtime
-RUN cat > /etc/vulkan/icd.d/nvidia_icd.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD": {
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194"
-    }
-}
-EOF
-RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
-    cat > /usr/share/glvnd/egl_vendor.d/10_nvidia.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "ICD" : {
-        "library_path" : "libEGL_nvidia.so.0"
-    }
-}
-EOF
-RUN cat > /etc/vulkan/implicit_layer.d/nvidia_layers.json <<EOF
-{
-    "file_format_version" : "1.0.0",
-    "layer": {
-        "name": "VK_LAYER_NV_optimus",
-        "type": "INSTANCE",
-        "library_path": "libGLX_nvidia.so.0",
-        "api_version" : "1.3.194",
-        "implementation_version" : "1",
-        "description" : "NVIDIA Optimus layer",
-        "functions": {
-            "vkGetInstanceProcAddr": "vk_optimusGetInstanceProcAddr",
-            "vkGetDeviceProcAddr": "vk_optimusGetDeviceProcAddr"
-        },
-        "enable_environment": {
-            "__NV_PRIME_RENDER_OFFLOAD": "1"
-        },
-        "disable_environment": {
-            "DISABLE_LAYER_NV_OPTIMUS_1": ""
-        }
-    }
-}
-EOF
+# Install GUI debugging tools and configure Vulkan
+COPY --chown=root:root modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
 # Install ROS2 Gazebo packages for amd64
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -145,44 +89,14 @@ USER $USERNAME
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
-# Install `libxrandr2` to support Isaac Sim WebRTC streaming
+# Isaac Sim version configuration
+ARG ISAAC_SIM_VERSION=4.2.0.2
+# Copy and run Isaac Sim installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo apt-get update && sudo apt-get install -y \
-        libxrandr2 \
-        && sudo rm -rf /var/lib/apt/lists/*; \
-    fi
-# Install Isaac Sim (requires Python 3.10)
-# Note that installing Isaac Sim with pip is experimental, keep this in mind when unexpected error occurs
-# TODO: Remove the note above when it is no longer experimental
-# Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#installation-using-pip
-RUN --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        python3 -V | grep "Python 3.10" \
-        && pip install isaacsim==4.2.0.2 --extra-index-url https://pypi.nvidia.com \
-        && pip install isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com; \
-    fi
-
-# Fix SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) `numpy==1.26.0`, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        pip install scipy==1.14.1 numpy==1.26.0; \
-    fi
-
-# Create isaac sim cache directory with correct ownership to avoid permission issues after volume mount, only for amd64
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        sudo mkdir -p /isaac-sim/kit/cache \
-        && sudo chown -R $USERNAME:$USERNAME /isaac-sim/kit/cache; \
-    fi
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        mkdir -p /home/$USERNAME/.cache/ov \
-        && mkdir -p /home/$USERNAME/.cache/pip \
-        && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-        && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-        && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-        && mkdir -p /home/$USERNAME/.local/share/ov/data \
-        && mkdir -p /home/$USERNAME/Documents; \
-    fi
-
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53

--- a/vlp_ws/docker/Dockerfile
+++ b/vlp_ws/docker/Dockerfile
@@ -90,7 +90,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.5.0.0
+ARG ISAAC_SIM_VERSION=4.5.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/vlp_ws/docker/Dockerfile
+++ b/vlp_ws/docker/Dockerfile
@@ -90,7 +90,7 @@ USER $USERNAME
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
-ARG ISAAC_SIM_VERSION=4.2.0.2
+ARG ISAAC_SIM_VERSION=4.5.0.0
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh

--- a/vlp_ws/docker/Dockerfile
+++ b/vlp_ws/docker/Dockerfile
@@ -104,6 +104,17 @@ ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
 
+# Set TERM to prevent Isaac Lab error during docker build:
+#    'ansi+tabs': unknown terminal type.
+ENV TERM=xterm-256color
+# Isaac Lab version configuration
+ARG ISAAC_LAB_VERSION=2.1.0
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
+    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     sudo apt-get update && sudo apt-get install -y \

--- a/vlp_ws/docker/compose.yaml
+++ b/vlp_ws/docker/compose.yaml
@@ -23,6 +23,9 @@ services:
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
       #   ISAAC_SIM_VERSION: "4.5.0"
+      # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
+      # args:
+      #   ISAAC_LAB_VERSION: "2.1.0"
       cache_from:
         - j3soon/ros2-vlp-ws:buildcache-amd64
         - j3soon/ros2-vlp-ws:buildcache-arm64

--- a/vlp_ws/docker/compose.yaml
+++ b/vlp_ws/docker/compose.yaml
@@ -7,8 +7,7 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        mkdir -p /isaac-sim/standalone/{logs,data}"
     volumes:
       - isaac-sim-cache:/isaac-sim
   vlp-ws:

--- a/vlp_ws/docker/compose.yaml
+++ b/vlp_ws/docker/compose.yaml
@@ -21,6 +21,9 @@ services:
       # Reference: https://docs.docker.com/compose/compose-file/build/#platforms
       # platforms:
       #   - "linux/arm64"
+      # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
+      # args:
+      #   ISAAC_SIM_VERSION: "4.2.0.2"
       cache_from:
         - j3soon/ros2-vlp-ws:buildcache-amd64
         - j3soon/ros2-vlp-ws:buildcache-arm64

--- a/vlp_ws/docker/compose.yaml
+++ b/vlp_ws/docker/compose.yaml
@@ -22,7 +22,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.5.0.0"
+      #   ISAAC_SIM_VERSION: "4.5.0"
       cache_from:
         - j3soon/ros2-vlp-ws:buildcache-amd64
         - j3soon/ros2-vlp-ws:buildcache-arm64

--- a/vlp_ws/docker/compose.yaml
+++ b/vlp_ws/docker/compose.yaml
@@ -23,7 +23,7 @@ services:
       #   - "linux/arm64"
       # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
       # args:
-      #   ISAAC_SIM_VERSION: "4.2.0.2"
+      #   ISAAC_SIM_VERSION: "4.5.0.0"
       cache_from:
         - j3soon/ros2-vlp-ws:buildcache-amd64
         - j3soon/ros2-vlp-ws:buildcache-arm64


### PR DESCRIPTION
- Add Docker modules and make them configurable through `ARG`
  - This allows not installing Isaac Sim for amd64 deployment code as suggested by @YuZhong-Chen 
- Add Isaac Sim 4.5.0 binary install
- Add Isaac Lab 2.1.0 git install
- Will now require the `post_install.sh` script to be ran after clone