### PR TITLE
Add CUDA Toolkit and Base Isaac ROS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Some current CI builds are flaky and may require re-running.
 ```sh
 # cd into a workspace directory's docker directory
 docker compose down --volumes --remove-orphans
+docker volume rm ros2-gazebo-cache
+docker volume rm ros2-isaac-sim-cache
 ```
 
 ## Acknowledgement

--- a/aloha_ws/docker/.bashrc
+++ b/aloha_ws/docker/.bashrc
@@ -7,25 +7,7 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
-# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
-echo "changing ownership of Isaac Sim user cache directories..."
-sudo chown user:user /isaac-sim
-sudo chown user:user /isaac-sim/kit
-sudo chown user:user /isaac-sim/kit/cache
-sudo chown user:user /home/user/.cache
-sudo chown user:user /home/user/.cache/ov
-sudo chown user:user /home/user/.cache/pip
-sudo chown user:user /home/user/.cache/nvidia
-sudo chown user:user /home/user/.cache/nvidia/GLCache
-sudo chown user:user /home/user/.nv
-sudo chown user:user /home/user/.nv/ComputeCache
-sudo chown user:user /home/user/.nvidia-omniverse
-sudo chown user:user /home/user/.nvidia-omniverse/logs
-sudo chown user:user /home/user/.local/share/ov
-sudo chown user:user /home/user/.local/share/ov/data
-sudo chown user:user /home/user/Documents
-# Set the CycloneDDS configuration file
-export CYCLONEDDS_URI=/home/user/cyclonedds.xml
+
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/aloha_ws/docker/Dockerfile
+++ b/aloha_ws/docker/Dockerfile
@@ -27,10 +27,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get update && apt-get install -y \
     curl \
     git \
+    git-lfs \
     htop \
     iputils-ping \
+    jq \
     nano \
     net-tools \
+    netcat-traditional \
+    nmap \
     tmux \
     tree \
     unzip \
@@ -52,6 +56,8 @@ ENV ROS_DISTRO=$ROS_DISTRO
 COPY modules/install_ros.sh /tmp/install_ros.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_ros.sh && rm /tmp/install_ros.sh
+# Set the CycloneDDS configuration file
+ENV CYCLONEDDS_URI=/home/user/cyclonedds.xml
 
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
@@ -62,6 +68,16 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 COPY modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
+
+# Install CUDA Toolkit (not installed by default)
+ARG CUDA_TOOLKIT_VERSION=""
+# Copy and run CUDA Toolkit installation script
+COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
+# Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#post-installation-actions
+ENV PATH="${PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/lib64"
 
 # Arguments for the default user
 ARG USERNAME=user
@@ -77,34 +93,52 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 
 USER $USERNAME
 
+# Create cache directories with correct ownership to avoid permission issues after volume mount
+RUN mkdir -p /home/$USERNAME/.cache/pip
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53
 ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
+ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
+# Isaac ROS version configuration
+ARG ISAAC_ROS=YES
+ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
+# Copy and run Isaac ROS installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+# Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -155,7 +189,7 @@ COPY --chown=$USERNAME:$USERNAME \
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     bash -ie ~/xsarm_amd64_install.sh -d humble -n \
     && sudo rm -rf /var/lib/apt/lists/* \
-    && rm -rf $HOME/.ros/rosdep/sources.cache
+    && rm -rf /home/$USERNAME/.ros/rosdep/sources.cache
 COPY udev_rules/99-interbotix-udev.rules /etc/udev/rules.d/
 
 COPY --chown=$USERNAME:$USERNAME \

--- a/aloha_ws/docker/compose.yaml
+++ b/aloha_ws/docker/compose.yaml
@@ -8,7 +8,8 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data}"
+        mkdir -p /isaac-sim/standalone/{logs,data} &&
+        chown -R 1000:1000 /isaac-sim"
     volumes:
       - isaac-sim-cache:/isaac-sim
   aloha-ws:
@@ -24,10 +25,14 @@ services:
       args:
         # TODO: Set the USER_UID
         USER_UID: "${USER_UID:-1000}"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
         # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
       cache_from:
         - j3soon/ros2-aloha-ws:buildcache-amd64
         - j3soon/ros2-aloha-ws:buildcache-arm64

--- a/aloha_ws/docker/compose.yaml
+++ b/aloha_ws/docker/compose.yaml
@@ -5,11 +5,20 @@ services:
     image: ubuntu:22.04
     container_name: ros2-aloha-ws-volume-instantiation
     command: bash -c "
+        echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
         mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+        "
     volumes:
       - isaac-sim-cache:/isaac-sim
   aloha-ws:

--- a/cartographer_ws/docker/.bashrc
+++ b/cartographer_ws/docker/.bashrc
@@ -7,25 +7,7 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
-# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
-echo "changing ownership of Isaac Sim user cache directories..."
-sudo chown user:user /isaac-sim
-sudo chown user:user /isaac-sim/kit
-sudo chown user:user /isaac-sim/kit/cache
-sudo chown user:user /home/user/.cache
-sudo chown user:user /home/user/.cache/ov
-sudo chown user:user /home/user/.cache/pip
-sudo chown user:user /home/user/.cache/nvidia
-sudo chown user:user /home/user/.cache/nvidia/GLCache
-sudo chown user:user /home/user/.nv
-sudo chown user:user /home/user/.nv/ComputeCache
-sudo chown user:user /home/user/.nvidia-omniverse
-sudo chown user:user /home/user/.nvidia-omniverse/logs
-sudo chown user:user /home/user/.local/share/ov
-sudo chown user:user /home/user/.local/share/ov/data
-sudo chown user:user /home/user/Documents
-# Set the CycloneDDS configuration file
-export CYCLONEDDS_URI=/home/user/cyclonedds.xml
+
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/cartographer_ws/docker/Dockerfile
+++ b/cartographer_ws/docker/Dockerfile
@@ -27,10 +27,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get update && apt-get install -y \
     curl \
     git \
+    git-lfs \
     htop \
     iputils-ping \
+    jq \
     nano \
     net-tools \
+    netcat-traditional \
+    nmap \
     tmux \
     tree \
     unzip \
@@ -52,6 +56,8 @@ ENV ROS_DISTRO=$ROS_DISTRO
 COPY modules/install_ros.sh /tmp/install_ros.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_ros.sh && rm /tmp/install_ros.sh
+# Set the CycloneDDS configuration file
+ENV CYCLONEDDS_URI=/home/user/cyclonedds.xml
 
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
@@ -62,6 +68,16 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 COPY modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
+
+# Install CUDA Toolkit (not installed by default)
+ARG CUDA_TOOLKIT_VERSION=""
+# Copy and run CUDA Toolkit installation script
+COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
+# Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#post-installation-actions
+ENV PATH="${PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/lib64"
 
 # Arguments for the default user
 ARG USERNAME=user
@@ -77,34 +93,52 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 
 USER $USERNAME
 
+# Create cache directories with correct ownership to avoid permission issues after volume mount
+RUN mkdir -p /home/$USERNAME/.cache/pip
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53
 ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
+ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
+# Isaac ROS version configuration
+ARG ISAAC_ROS=YES
+ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
+# Copy and run Isaac ROS installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+# Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/cartographer_ws/docker/compose.yaml
+++ b/cartographer_ws/docker/compose.yaml
@@ -8,7 +8,8 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data}"
+        mkdir -p /isaac-sim/standalone/{logs,data} &&
+        chown -R 1000:1000 /isaac-sim"
     volumes:
       - isaac-sim-cache:/isaac-sim
   cartographer-ws:
@@ -24,10 +25,14 @@ services:
       args:
         # TODO: Set the USER_UID
         USER_UID: "${USER_UID:-1000}"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
         # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
       cache_from:
         - j3soon/ros2-cartographer-ws:buildcache-amd64
         - j3soon/ros2-cartographer-ws:buildcache-arm64

--- a/cartographer_ws/docker/compose.yaml
+++ b/cartographer_ws/docker/compose.yaml
@@ -5,11 +5,20 @@ services:
     image: ubuntu:22.04
     container_name: ros2-cartographer-ws-volume-instantiation
     command: bash -c "
+        echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
         mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+        "
     volumes:
       - isaac-sim-cache:/isaac-sim
   cartographer-ws:

--- a/delto_gripper_ws/docker/.bashrc
+++ b/delto_gripper_ws/docker/.bashrc
@@ -7,25 +7,7 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
-# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
-echo "changing ownership of Isaac Sim user cache directories..."
-sudo chown user:user /isaac-sim
-sudo chown user:user /isaac-sim/kit
-sudo chown user:user /isaac-sim/kit/cache
-sudo chown user:user /home/user/.cache
-sudo chown user:user /home/user/.cache/ov
-sudo chown user:user /home/user/.cache/pip
-sudo chown user:user /home/user/.cache/nvidia
-sudo chown user:user /home/user/.cache/nvidia/GLCache
-sudo chown user:user /home/user/.nv
-sudo chown user:user /home/user/.nv/ComputeCache
-sudo chown user:user /home/user/.nvidia-omniverse
-sudo chown user:user /home/user/.nvidia-omniverse/logs
-sudo chown user:user /home/user/.local/share/ov
-sudo chown user:user /home/user/.local/share/ov/data
-sudo chown user:user /home/user/Documents
-# Set the CycloneDDS configuration file
-export CYCLONEDDS_URI=/home/user/cyclonedds.xml
+
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/delto_gripper_ws/docker/Dockerfile
+++ b/delto_gripper_ws/docker/Dockerfile
@@ -27,10 +27,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get update && apt-get install -y \
     curl \
     git \
+    git-lfs \
     htop \
     iputils-ping \
+    jq \
     nano \
     net-tools \
+    netcat-traditional \
+    nmap \
     tmux \
     tree \
     unzip \
@@ -52,6 +56,8 @@ ENV ROS_DISTRO=$ROS_DISTRO
 COPY modules/install_ros.sh /tmp/install_ros.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_ros.sh && rm /tmp/install_ros.sh
+# Set the CycloneDDS configuration file
+ENV CYCLONEDDS_URI=/home/user/cyclonedds.xml
 
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
@@ -62,6 +68,16 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 COPY modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
+
+# Install CUDA Toolkit (not installed by default)
+ARG CUDA_TOOLKIT_VERSION=""
+# Copy and run CUDA Toolkit installation script
+COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
+# Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#post-installation-actions
+ENV PATH="${PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/lib64"
 
 # Arguments for the default user
 ARG USERNAME=user
@@ -77,34 +93,52 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 
 USER $USERNAME
 
+# Create cache directories with correct ownership to avoid permission issues after volume mount
+RUN mkdir -p /home/$USERNAME/.cache/pip
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53
 ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
+ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
+# Isaac ROS version configuration
+ARG ISAAC_ROS=YES
+ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
+# Copy and run Isaac ROS installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+# Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/delto_gripper_ws/docker/compose.yaml
+++ b/delto_gripper_ws/docker/compose.yaml
@@ -8,7 +8,8 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data}"
+        mkdir -p /isaac-sim/standalone/{logs,data} &&
+        chown -R 1000:1000 /isaac-sim"
     volumes:
       - isaac-sim-cache:/isaac-sim
   delto-gripper-ws:
@@ -24,10 +25,14 @@ services:
       args:
         # TODO: Set the USER_UID
         USER_UID: "${USER_UID:-1000}"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
         # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
       cache_from:
         - j3soon/ros2-delto-gripper-ws:buildcache-amd64
         - j3soon/ros2-delto-gripper-ws:buildcache-arm64

--- a/delto_gripper_ws/docker/compose.yaml
+++ b/delto_gripper_ws/docker/compose.yaml
@@ -5,11 +5,20 @@ services:
     image: ubuntu:22.04
     container_name: ros2-delto-gripper-ws-volume-instantiation
     command: bash -c "
+        echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
         mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+        "
     volumes:
       - isaac-sim-cache:/isaac-sim
   delto-gripper-ws:

--- a/docker_modules/install_cuda_toolkit.sh
+++ b/docker_modules/install_cuda_toolkit.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+# Install CUDA Toolkit related components
+
+# Check required environment variables
+if [ -z "$TARGETARCH" ]; then
+    echo "Error: TARGETARCH environment variable is required but not set"
+    exit 1
+fi
+if [ -z "$CUDA_TOOLKIT_VERSION" ]; then
+    echo "Skipping CUDA Toolkit installation as CUDA_TOOLKIT_VERSION is not set"
+    exit 0
+fi
+
+echo "Installing CUDA Toolkit components for architecture: $TARGETARCH"
+echo "CUDA Toolkit version: $CUDA_TOOLKIT_VERSION"
+
+# Only install CUDA Toolkit components on amd64 architecture
+# We chose to use `deb (network)` installation for simplicity of changing across minor versions (no need to set driver version)
+# We may need to use other installation methods if we want to change the PATCH version (e.g. `deb (local)`)
+if [ "$TARGETARCH" == "amd64" ]; then
+    # Ref: https://developer.nvidia.com/cuda-toolkit-archive
+    # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#network-repo-installation-for-ubuntu
+    # Ref: https://developer.nvidia.com/cuda-12-6-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=deb_network
+    cd /tmp
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+    dpkg -i cuda-keyring_1.1-1_all.deb
+    rm cuda-keyring_1.1-1_all.deb
+    apt-get update
+    apt-get -y install cuda-toolkit-${CUDA_TOOLKIT_VERSION//./-}
+    rm -rf /var/lib/apt/lists/*
+
+    # Note: CUDA samples are not downloaded to minimize image size
+    # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#recommended-actions
+    # Ref: https://github., and can be installed easily later
+elif [ "$TARGETARCH" == "arm64" ]; then
+    echo "Not Implemented: CUDA Toolkit installation for architecture: $TARGETARCH"
+    exit 1
+else
+    echo "Skipping CUDA Toolkit installation for architecture: $TARGETARCH"
+    exit 0
+fi
+
+echo "CUDA Toolkit installation completed successfully!"

--- a/docker_modules/install_isaac_lab.sh
+++ b/docker_modules/install_isaac_lab.sh
@@ -43,11 +43,13 @@ if [ "$ISAAC_LAB_VERSION" = "2.1.0" ]; then
     # Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
     sudo apt-get update && sudo apt-get install -y \
         cmake build-essential \
-        && sudo rm -rf /var/lib/apt/lists/*
+        && sudo rm -rf /var/lib/apt/lists/* \
+        || exit 1
     git clone -b v2.1.0 https://github.com/isaac-sim/IsaacLab.git "$ISAACLAB_PATH" \
         && cd "$ISAACLAB_PATH" \
         && ln -s "$ISAACSIM_PATH" _isaac_sim \
-        && ./isaaclab.sh --install
+        && ./isaaclab.sh --install \
+        || exit 1
 else
     echo "Error: Unsupported Isaac Lab version: $ISAAC_LAB_VERSION"
     exit 1

--- a/docker_modules/install_isaac_lab.sh
+++ b/docker_modules/install_isaac_lab.sh
@@ -25,22 +25,23 @@ echo "Installing Isaac Lab for architecture: $TARGETARCH"
 echo "Isaac Lab version: $ISAAC_LAB_VERSION"
 
 # Only install Isaac Lab on amd64 architecture
-if [ "$TARGETARCH" = "amd64" ]; then
-    if [ "$ISAAC_LAB_VERSION" = "2.1.0" ]; then
-        echo "Installing Isaac Lab 2.1.0..."
-        # Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
-        sudo apt-get update && sudo apt-get install -y \
-            cmake build-essential \
-            && sudo rm -rf /var/lib/apt/lists/*
-        git clone -b v2.1.0 https://github.com/isaac-sim/IsaacLab.git ~/IsaacLab \
-            && cd ~/IsaacLab \
-            && ln -s ${HOME}/isaacsim _isaac_sim \
-            && ./isaaclab.sh --install
-    else
-        echo "Error: Unsupported Isaac Lab version: $ISAAC_LAB_VERSION"
-        exit 1
-    fi
-    echo "Isaac Lab installation completed successfully!"
-else
+if [ "$TARGETARCH" != "amd64" ]; then
     echo "Skipping Isaac Lab installation for architecture: $TARGETARCH (only supported on amd64)"
+    exit 0
 fi
+
+if [ "$ISAAC_LAB_VERSION" = "2.1.0" ]; then
+    echo "Installing Isaac Lab 2.1.0..."
+    # Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+    sudo apt-get update && sudo apt-get install -y \
+        cmake build-essential \
+        && sudo rm -rf /var/lib/apt/lists/*
+    git clone -b v2.1.0 https://github.com/isaac-sim/IsaacLab.git ~/IsaacLab \
+        && cd ~/IsaacLab \
+        && ln -s ${HOME}/isaacsim _isaac_sim \
+        && ./isaaclab.sh --install
+else
+    echo "Error: Unsupported Isaac Lab version: $ISAAC_LAB_VERSION"
+    exit 1
+fi
+echo "Isaac Lab installation completed successfully!"

--- a/docker_modules/install_isaac_lab.sh
+++ b/docker_modules/install_isaac_lab.sh
@@ -16,9 +16,17 @@ if [ -z "$ISAAC_SIM_VERSION" ]; then
     echo "Error: ISAAC_SIM_VERSION environment variable is required but not set"
     exit 1
 fi
+if [ -z "$ISAACSIM_PATH" ]; then
+    echo "Error: ISAACSIM_PATH environment variable is required but not set"
+    exit 1
+fi
 if [ -z "$ISAAC_LAB_VERSION" ]; then
     echo "Skipping Isaac Lab installation as ISAAC_LAB_VERSION is not set"
     exit 0
+fi
+if [ -z "$ISAACLAB_PATH" ]; then
+    echo "Error: ISAACLAB_PATH environment variable is required but not set"
+    exit 1
 fi
 
 echo "Installing Isaac Lab for architecture: $TARGETARCH"
@@ -36,9 +44,9 @@ if [ "$ISAAC_LAB_VERSION" = "2.1.0" ]; then
     sudo apt-get update && sudo apt-get install -y \
         cmake build-essential \
         && sudo rm -rf /var/lib/apt/lists/*
-    git clone -b v2.1.0 https://github.com/isaac-sim/IsaacLab.git ~/IsaacLab \
-        && cd ~/IsaacLab \
-        && ln -s ${HOME}/isaacsim _isaac_sim \
+    git clone -b v2.1.0 https://github.com/isaac-sim/IsaacLab.git "$ISAACLAB_PATH" \
+        && cd "$ISAACLAB_PATH" \
+        && ln -s "$ISAACSIM_PATH" _isaac_sim \
         && ./isaaclab.sh --install
 else
     echo "Error: Unsupported Isaac Lab version: $ISAAC_LAB_VERSION"

--- a/docker_modules/install_isaac_ros.sh
+++ b/docker_modules/install_isaac_ros.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+
+# Install Isaac ROS related components
+
+# Check required environment variables
+if [ -z "$USERNAME" ]; then
+    echo "Error: USERNAME environment variable is required but not set"
+    exit 1
+fi
+if [ -z "$TARGETARCH" ]; then
+    echo "Error: TARGETARCH environment variable is required but not set"
+    exit 1
+fi
+if [ -z "$ROS_DISTRO" ]; then
+    echo "Error: ROS_DISTRO environment variable is required but not set"
+    exit 1
+fi
+if [ -z "$ISAAC_ROS" ]; then
+    echo "Skipping Isaac ROS installation as ISAAC_ROS is not set"
+    exit 0
+fi
+if [ -z "$ISAAC_ROS_WS" ]; then
+    echo "Error: ISAAC_ROS_WS environment variable is required but not set"
+    exit 1
+fi
+
+echo "Installing Isaac ROS components for architecture: $TARGETARCH"
+echo "Isaac ROS: $ISAAC_ROS"
+
+# Only install Isaac ROS components on supported architectures
+if [ "$TARGETARCH" != "amd64" ] && [ "$TARGETARCH" != "arm64" ]; then
+    echo "Skipping Isaac ROS installation for architecture: $TARGETARCH (only supported on amd64 and arm64)"
+    exit 0
+fi
+
+if [ "$ROS_DISTRO" != "humble" ]; then
+    echo "Error: Unsupported ROS distribution $ROS_DISTRO"
+    exit 1
+fi
+
+if [ "$ISAAC_ROS" = "YES" ]; then
+    echo "Installing Isaac ROS..."
+    # Ref: https://nvidia-isaac-ros.github.io/getting_started/isaac_apt_repository.html
+    wget -qO - https://isaac.download.nvidia.com/isaac-ros/repos.key | sudo apt-key add -
+    grep -qxF "deb https://isaac.download.nvidia.com/isaac-ros/release-3 $(lsb_release -cs) release-3.0" /etc/apt/sources.list || \
+    echo "deb https://isaac.download.nvidia.com/isaac-ros/release-3 $(lsb_release -cs) release-3.0" | sudo tee -a /etc/apt/sources.list
+    sudo apt-get update && sudo rm -rf /var/lib/apt/lists/*
+
+    # Ref: https://nvidia-isaac-ros.github.io/repositories_and_packages/isaac_ros_nvblox/isaac_ros_nvblox/index.html
+    mkdir -p ${ISAAC_ROS_WS}/src
+    cd ${ISAAC_ROS_WS}/src
+    git clone -b release-3.2 https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_common.git isaac_ros_common
+else
+    echo "Error: Unsupported Isaac ROS: $ISAAC_ROS"
+    exit 1
+fi
+
+echo "Isaac ROS installation completed successfully!"

--- a/docker_modules/install_isaac_ros.sh
+++ b/docker_modules/install_isaac_ros.sh
@@ -24,12 +24,14 @@ if [ -z "$ISAAC_ROS_WS" ]; then
     echo "Error: ISAAC_ROS_WS environment variable is required but not set"
     exit 1
 fi
-if [ "$CUDA_TOOLKIT_VERSION" != "12.6" ]; then
-    # Ref: https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_common/blob/main/docker/Dockerfile.base
-    echo "Error: CUDA_TOOLKIT_VERSION must be 12.6 for Isaac ROS"
-    # Other versions may be supported, but we haven't tested them yet.
-    exit 1
-fi
+# TODO: Check if this check is necessary
+# Temporarily ignore CUDA Toolkit version check
+# if [ "$CUDA_TOOLKIT_VERSION" != "12.6" ]; then
+#     # Ref: https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_common/blob/main/docker/Dockerfile.base
+#     echo "Error: CUDA_TOOLKIT_VERSION must be 12.6 for Isaac ROS"
+#     # Other versions may be supported, but we haven't tested them yet.
+#     exit 1
+# fi
 
 echo "Installing Isaac ROS components for architecture: $TARGETARCH"
 echo "Isaac ROS: $ISAAC_ROS"

--- a/docker_modules/install_isaac_ros.sh
+++ b/docker_modules/install_isaac_ros.sh
@@ -24,6 +24,12 @@ if [ -z "$ISAAC_ROS_WS" ]; then
     echo "Error: ISAAC_ROS_WS environment variable is required but not set"
     exit 1
 fi
+if [ "$CUDA_TOOLKIT_VERSION" != "12.6" ]; then
+    # Ref: https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_common/blob/main/docker/Dockerfile.base
+    echo "Error: CUDA_TOOLKIT_VERSION must be 12.6 for Isaac ROS"
+    # Other versions may be supported, but we haven't tested them yet.
+    exit 1
+fi
 
 echo "Installing Isaac ROS components for architecture: $TARGETARCH"
 echo "Isaac ROS: $ISAAC_ROS"

--- a/docker_modules/install_isaac_ros.sh
+++ b/docker_modules/install_isaac_ros.sh
@@ -51,7 +51,7 @@ if [ "$ISAAC_ROS" = "YES" ]; then
     wget -qO - https://isaac.download.nvidia.com/isaac-ros/repos.key | sudo apt-key add -
     grep -qxF "deb https://isaac.download.nvidia.com/isaac-ros/release-3 $(lsb_release -cs) release-3.0" /etc/apt/sources.list || \
     echo "deb https://isaac.download.nvidia.com/isaac-ros/release-3 $(lsb_release -cs) release-3.0" | sudo tee -a /etc/apt/sources.list
-    sudo apt-get update && sudo rm -rf /var/lib/apt/lists/*
+    sudo apt-get update && sudo rm -rf /var/lib/apt/lists/* || exit 1
 
     # Ref: https://nvidia-isaac-ros.github.io/repositories_and_packages/isaac_ros_nvblox/isaac_ros_nvblox/index.html
     mkdir -p ${ISAAC_ROS_WS}/src

--- a/docker_modules/install_isaac_sim.sh
+++ b/docker_modules/install_isaac_sim.sh
@@ -33,7 +33,8 @@ fi
 echo "Installing 'libglu1-mesa' for Iray and 'libxrandr2' to support Isaac Sim WebRTC streaming..."
 sudo apt-get update && sudo apt-get install -y \
     libglu1-mesa libxrandr2 \
-    && sudo rm -rf /var/lib/apt/lists/*
+    && sudo rm -rf /var/lib/apt/lists/* \
+    || exit 1
 
 if [ "$ISAAC_SIM_VERSION" = "4.5.0" ]; then
     echo "Installing Isaac Sim Compatibility Checker 4.5.0..."
@@ -43,7 +44,8 @@ if [ "$ISAAC_SIM_VERSION" = "4.5.0" ]; then
         && cd /tmp \
         && wget -q https://download.isaacsim.omniverse.nvidia.com/isaac-sim-comp-check%404.5.0-rc.6%2Brelease.675.f1cca148.gl.linux-x86_64.release.zip \
         && unzip "isaac-sim-comp-check@4.5.0-rc.6+release.675.f1cca148.gl.linux-x86_64.release.zip" -d ~/isaac-sim-comp-check \
-        && rm "isaac-sim-comp-check@4.5.0-rc.6+release.675.f1cca148.gl.linux-x86_64.release.zip"
+        && rm "isaac-sim-comp-check@4.5.0-rc.6+release.675.f1cca148.gl.linux-x86_64.release.zip" \
+        || exit 1
     echo "Installing Isaac Sim 4.5.0 (requires Python 3.10)..."
     # Ref: https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/install_workstation.html
     python3 -V | grep "Python 3.10" \
@@ -52,7 +54,8 @@ if [ "$ISAAC_SIM_VERSION" = "4.5.0" ]; then
         && unzip "isaac-sim-standalone@4.5.0-rc.36+release.19112.f59b3005.gl.linux-x86_64.release.zip" -d "$ISAACSIM_PATH" \
         && rm "isaac-sim-standalone@4.5.0-rc.36+release.19112.f59b3005.gl.linux-x86_64.release.zip" \
         && cd "$ISAACSIM_PATH" \
-        && ./post_install.sh
+        && ./post_install.sh \
+        || exit 1
 
     # Note: Optional dependencies and the Isaac Sim ROS workspace are not installed to minimize image size
     # Ref: https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/install_ros.html#running-native-ros
@@ -66,7 +69,7 @@ echo "Fixing SciPy (in base image) incompatibility with NumPy version (in Isaac 
 pip install scipy==1.14.1 numpy==1.26.0
 
 echo "Creating Isaac Sim directories with correct ownership to avoid permission issues after volume mount..."
-sudo mkdir -p /isaac-sim && sudo chown $USERNAME:$USERNAME /isaac-sim
+sudo mkdir -p /isaac-sim && sudo chown $USERNAME:$USERNAME /isaac-sim || exit 1
 mkdir -p /isaac-sim/kit/cache \
     && mkdir -p /home/$USERNAME/.cache/ov \
     && mkdir -p /home/$USERNAME/.local/lib/python3.10/site-packages/omni/cache \
@@ -77,6 +80,7 @@ mkdir -p /isaac-sim/kit/cache \
     && mkdir -p /home/$USERNAME/.local/lib/python3.10/site-packages/omni/logs \
     && mkdir -p /home/$USERNAME/.local/share/ov/data \
     && mkdir -p /home/$USERNAME/.local/lib/python3.10/site-packages/omni/data \
-    && mkdir -p /home/$USERNAME/Documents
+    && mkdir -p /home/$USERNAME/Documents \
+    || exit 1
 
 echo "Isaac Sim installation completed successfully!"

--- a/docker_modules/install_isaac_sim.sh
+++ b/docker_modules/install_isaac_sim.sh
@@ -16,6 +16,10 @@ if [ -z "$ISAAC_SIM_VERSION" ]; then
     echo "Skipping Isaac Sim installation as ISAAC_SIM_VERSION is not set"
     exit 0
 fi
+if [ -z "$ISAACSIM_PATH" ]; then
+    echo "Error: ISAACSIM_PATH environment variable is required but not set"
+    exit 1
+fi
 
 echo "Installing Isaac Sim components for architecture: $TARGETARCH"
 echo "Isaac Sim version: $ISAAC_SIM_VERSION"
@@ -35,18 +39,18 @@ if [ "$ISAAC_SIM_VERSION" = "4.5.0" ]; then
     echo "Installing Isaac Sim Compatibility Checker 4.5.0..."
     # Ref: https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/requirements.html#isaac-sim-compatibility-checker
     python3 -V | grep "Python 3.10" \
-        && cd ~ \
+        && cd /tmp \
         && wget -q https://download.isaacsim.omniverse.nvidia.com/isaac-sim-comp-check%404.5.0-rc.6%2Brelease.675.f1cca148.gl.linux-x86_64.release.zip \
         && unzip "isaac-sim-comp-check@4.5.0-rc.6+release.675.f1cca148.gl.linux-x86_64.release.zip" -d ~/isaac-sim-comp-check \
         && rm "isaac-sim-comp-check@4.5.0-rc.6+release.675.f1cca148.gl.linux-x86_64.release.zip"
     echo "Installing Isaac Sim 4.5.0 (requires Python 3.10)..."
     # Ref: https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/install_workstation.html
     python3 -V | grep "Python 3.10" \
-        && cd ~ \
+        && cd /tmp \
         && wget -q https://download.isaacsim.omniverse.nvidia.com/isaac-sim-standalone%404.5.0-rc.36%2Brelease.19112.f59b3005.gl.linux-x86_64.release.zip \
-        && unzip "isaac-sim-standalone@4.5.0-rc.36+release.19112.f59b3005.gl.linux-x86_64.release.zip" -d ~/isaacsim \
+        && unzip "isaac-sim-standalone@4.5.0-rc.36+release.19112.f59b3005.gl.linux-x86_64.release.zip" -d "$ISAACSIM_PATH" \
         && rm "isaac-sim-standalone@4.5.0-rc.36+release.19112.f59b3005.gl.linux-x86_64.release.zip" \
-        && cd ~/isaacsim \
+        && cd "$ISAACSIM_PATH" \
         && ./post_install.sh
 else
     echo "Error: Unsupported Isaac Sim version: $ISAAC_SIM_VERSION"

--- a/docker_modules/install_isaac_sim.sh
+++ b/docker_modules/install_isaac_sim.sh
@@ -21,38 +21,39 @@ echo "Installing Isaac Sim components for architecture: $TARGETARCH"
 echo "Isaac Sim version: $ISAAC_SIM_VERSION"
 
 # Only install Isaac Sim components on amd64 architecture
-if [ "$TARGETARCH" = "amd64" ]; then
-    echo "Installing `libglu1-mesa` for Iray and `libxrandr2` to support Isaac Sim WebRTC streaming..."
-    sudo apt-get update && sudo apt-get install -y \
-        libglu1-mesa libxrandr2 \
-        && sudo rm -rf /var/lib/apt/lists/*
-
-    if [ "$ISAAC_SIM_VERSION" = "4.5.0" ]; then
-        echo "Installing Isaac Sim Compatibility Checker 4.5.0..."
-        # Ref: https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/requirements.html#isaac-sim-compatibility-checker
-        python3 -V | grep "Python 3.10" \
-            && cd ~ \
-            && wget -q https://download.isaacsim.omniverse.nvidia.com/isaac-sim-comp-check%404.5.0-rc.6%2Brelease.675.f1cca148.gl.linux-x86_64.release.zip \
-            && unzip "isaac-sim-comp-check@4.5.0-rc.6+release.675.f1cca148.gl.linux-x86_64.release.zip" -d ~/isaac-sim-comp-check \
-            && rm "isaac-sim-comp-check@4.5.0-rc.6+release.675.f1cca148.gl.linux-x86_64.release.zip"
-        echo "Installing Isaac Sim 4.5.0 (requires Python 3.10)..."
-        # Ref: https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/install_workstation.html
-        python3 -V | grep "Python 3.10" \
-            && cd ~ \
-            && wget -q https://download.isaacsim.omniverse.nvidia.com/isaac-sim-standalone%404.5.0-rc.36%2Brelease.19112.f59b3005.gl.linux-x86_64.release.zip \
-            && unzip "isaac-sim-standalone@4.5.0-rc.36+release.19112.f59b3005.gl.linux-x86_64.release.zip" -d ~/isaacsim \
-            && rm "isaac-sim-standalone@4.5.0-rc.36+release.19112.f59b3005.gl.linux-x86_64.release.zip" \
-            && cd ~/isaacsim \
-            && ./post_install.sh
-    else
-        echo "Error: Unsupported Isaac Sim version: $ISAAC_SIM_VERSION"
-        exit 1
-    fi
-
-    echo "Fixing SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) numpy==1.26.0..."
-    pip install scipy==1.14.1 numpy==1.26.0
-
-    echo "Isaac Sim installation completed successfully!"
-else
+if [ "$TARGETARCH" != "amd64" ]; then
     echo "Skipping Isaac Sim installation for architecture: $TARGETARCH (only supported on amd64)"
+    exit 0
 fi
+
+echo "Installing 'libglu1-mesa' for Iray and 'libxrandr2' to support Isaac Sim WebRTC streaming..."
+sudo apt-get update && sudo apt-get install -y \
+    libglu1-mesa libxrandr2 \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+if [ "$ISAAC_SIM_VERSION" = "4.5.0" ]; then
+    echo "Installing Isaac Sim Compatibility Checker 4.5.0..."
+    # Ref: https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/requirements.html#isaac-sim-compatibility-checker
+    python3 -V | grep "Python 3.10" \
+        && cd ~ \
+        && wget -q https://download.isaacsim.omniverse.nvidia.com/isaac-sim-comp-check%404.5.0-rc.6%2Brelease.675.f1cca148.gl.linux-x86_64.release.zip \
+        && unzip "isaac-sim-comp-check@4.5.0-rc.6+release.675.f1cca148.gl.linux-x86_64.release.zip" -d ~/isaac-sim-comp-check \
+        && rm "isaac-sim-comp-check@4.5.0-rc.6+release.675.f1cca148.gl.linux-x86_64.release.zip"
+    echo "Installing Isaac Sim 4.5.0 (requires Python 3.10)..."
+    # Ref: https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/install_workstation.html
+    python3 -V | grep "Python 3.10" \
+        && cd ~ \
+        && wget -q https://download.isaacsim.omniverse.nvidia.com/isaac-sim-standalone%404.5.0-rc.36%2Brelease.19112.f59b3005.gl.linux-x86_64.release.zip \
+        && unzip "isaac-sim-standalone@4.5.0-rc.36+release.19112.f59b3005.gl.linux-x86_64.release.zip" -d ~/isaacsim \
+        && rm "isaac-sim-standalone@4.5.0-rc.36+release.19112.f59b3005.gl.linux-x86_64.release.zip" \
+        && cd ~/isaacsim \
+        && ./post_install.sh
+else
+    echo "Error: Unsupported Isaac Sim version: $ISAAC_SIM_VERSION"
+    exit 1
+fi
+
+echo "Fixing SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) numpy==1.26.0..."
+pip install scipy==1.14.1 numpy==1.26.0
+
+echo "Isaac Sim installation completed successfully!"

--- a/docker_modules/install_isaac_sim.sh
+++ b/docker_modules/install_isaac_sim.sh
@@ -60,4 +60,18 @@ fi
 echo "Fixing SciPy (in base image) incompatibility with NumPy version (in Isaac Sim) numpy==1.26.0..."
 pip install scipy==1.14.1 numpy==1.26.0
 
+echo "Creating Isaac Sim directories with correct ownership to avoid permission issues after volume mount..."
+sudo mkdir -p /isaac-sim && sudo chown $USERNAME:$USERNAME /isaac-sim
+mkdir -p /isaac-sim/kit/cache \
+    && mkdir -p /home/$USERNAME/.cache/ov \
+    && mkdir -p /home/$USERNAME/.local/lib/python3.10/site-packages/omni/cache \
+    && mkdir -p /home/$USERNAME/.cache/pip \
+    && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
+    && mkdir -p /home/$USERNAME/.nv/ComputeCache \
+    && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
+    && mkdir -p /home/$USERNAME/.local/lib/python3.10/site-packages/omni/logs \
+    && mkdir -p /home/$USERNAME/.local/share/ov/data \
+    && mkdir -p /home/$USERNAME/.local/lib/python3.10/site-packages/omni/data \
+    && mkdir -p /home/$USERNAME/Documents
+
 echo "Isaac Sim installation completed successfully!"

--- a/docker_modules/install_isaac_sim.sh
+++ b/docker_modules/install_isaac_sim.sh
@@ -37,6 +37,7 @@ sudo apt-get update && sudo apt-get install -y \
 
 if [ "$ISAAC_SIM_VERSION" = "4.5.0" ]; then
     echo "Installing Isaac Sim Compatibility Checker 4.5.0..."
+    # Note: The Isaac Sim Compatibility Checker is installed since its usefulness outweighs the image size increase
     # Ref: https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/requirements.html#isaac-sim-compatibility-checker
     python3 -V | grep "Python 3.10" \
         && cd /tmp \
@@ -52,6 +53,10 @@ if [ "$ISAAC_SIM_VERSION" = "4.5.0" ]; then
         && rm "isaac-sim-standalone@4.5.0-rc.36+release.19112.f59b3005.gl.linux-x86_64.release.zip" \
         && cd "$ISAACSIM_PATH" \
         && ./post_install.sh
+
+    # Note: Optional dependencies and the Isaac Sim ROS workspace are not installed to minimize image size
+    # Ref: https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/install_ros.html#running-native-ros
+    # Ref: https://docs.isaacsim.omniverse.nvidia.com/4.5.0/installation/install_ros.html#setting-up-workspaces
 else
     echo "Error: Unsupported Isaac Sim version: $ISAAC_SIM_VERSION"
     exit 1

--- a/docker_modules/install_ros.sh
+++ b/docker_modules/install_ros.sh
@@ -68,7 +68,7 @@ apt-get install -y /tmp/ros2-apt-source.deb
 rm -rf /tmp/ros2-apt-source.deb
 
 # Install ROS 2 packages
-apt-get update && apt-get upgrade -y
+apt-get update && apt-get upgrade -y || exit 1
 apt-get install -y \
     ros-$ROS_DISTRO-desktop \
     ros-dev-tools

--- a/docker_modules/install_x11_opengl_vulkan.sh
+++ b/docker_modules/install_x11_opengl_vulkan.sh
@@ -17,7 +17,8 @@ apt-get update && apt-get install -y \
     x11-apps x11-utils \
     mesa-utils \
     libgl1 vulkan-tools \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    || exit 1
 
 echo "Configuring Vulkan support..."
 # Install Vulkan config files

--- a/docs/docker-modules/index.md
+++ b/docs/docker-modules/index.md
@@ -1,8 +1,24 @@
 # Docker Modules
 
+## Robot Operating System 2 (ROS 2)
+
+ROS 2 Humble Apt Install.
+
+## CUDA Toolkit
+
+CUDA Toolkit 12.6 Deb Install.
+
+> This is often unnecessary when only Python is used, as `pip install torch` typically installs the appropriate version of the CUDA Toolkit automatically.
+
 ## Isaac Sim
 
 Isaac Sim 4.5.0 Binary Install.
+
+Depends on:
+- Vulkan Configuration
+- Username
+
+> Note that CUDA Toolkit is not required for Isaac Sim.
 
 ### On Host
 
@@ -41,6 +57,13 @@ cd ~/isaacsim
 
 Isaac Lab 2.1.0 Git Install.
 
+Depends on:
+- Vulkan Configuration
+- Username
+- Isaac Sim
+
+> Note that CUDA Toolkit is not required for Isaac Lab.
+
 ### On Host
 
 Quick test using official Docker image:
@@ -69,3 +92,14 @@ cd ~/IsaacLab
 # or
 ./isaaclab.sh -p scripts/reinforcement_learning/skrl/train.py --task=Isaac-Cartpole-v0 --headless
 ```
+
+## Isaac ROS
+
+> Note: This is a work in progress. Currently only the base Isaac ROS is installed. Running examples requires additional dependencies that are not yet included in this setup.
+
+Isaac ROS 3.2.
+
+Depends on:
+- ROS 2 Humble
+- CUDA Toolkit
+- and more...

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,6 +140,8 @@ Some current CI builds are flaky and may require re-running.
 ```sh
 # cd into a workspace directory's docker directory
 docker compose down --volumes --remove-orphans
+docker volume rm ros2-gazebo-cache
+docker volume rm ros2-isaac-sim-cache
 ```
 
 ## Acknowledgement

--- a/gazebo_world_ws/docker/.bashrc
+++ b/gazebo_world_ws/docker/.bashrc
@@ -7,25 +7,7 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
-# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
-echo "changing ownership of Isaac Sim user cache directories..."
-sudo chown user:user /isaac-sim
-sudo chown user:user /isaac-sim/kit
-sudo chown user:user /isaac-sim/kit/cache
-sudo chown user:user /home/user/.cache
-sudo chown user:user /home/user/.cache/ov
-sudo chown user:user /home/user/.cache/pip
-sudo chown user:user /home/user/.cache/nvidia
-sudo chown user:user /home/user/.cache/nvidia/GLCache
-sudo chown user:user /home/user/.nv
-sudo chown user:user /home/user/.nv/ComputeCache
-sudo chown user:user /home/user/.nvidia-omniverse
-sudo chown user:user /home/user/.nvidia-omniverse/logs
-sudo chown user:user /home/user/.local/share/ov
-sudo chown user:user /home/user/.local/share/ov/data
-sudo chown user:user /home/user/Documents
-# Set the CycloneDDS configuration file
-export CYCLONEDDS_URI=/home/user/cyclonedds.xml
+
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/gazebo_world_ws/docker/Dockerfile
+++ b/gazebo_world_ws/docker/Dockerfile
@@ -27,10 +27,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get update && apt-get install -y \
     curl \
     git \
+    git-lfs \
     htop \
     iputils-ping \
+    jq \
     nano \
     net-tools \
+    netcat-traditional \
+    nmap \
     tmux \
     tree \
     unzip \
@@ -52,6 +56,8 @@ ENV ROS_DISTRO=$ROS_DISTRO
 COPY modules/install_ros.sh /tmp/install_ros.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_ros.sh && rm /tmp/install_ros.sh
+# Set the CycloneDDS configuration file
+ENV CYCLONEDDS_URI=/home/user/cyclonedds.xml
 
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
@@ -62,6 +68,16 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 COPY modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
+
+# Install CUDA Toolkit (not installed by default)
+ARG CUDA_TOOLKIT_VERSION=""
+# Copy and run CUDA Toolkit installation script
+COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
+# Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#post-installation-actions
+ENV PATH="${PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/lib64"
 
 # Arguments for the default user
 ARG USERNAME=user
@@ -77,34 +93,52 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 
 USER $USERNAME
 
+# Create cache directories with correct ownership to avoid permission issues after volume mount
+RUN mkdir -p /home/$USERNAME/.cache/pip
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53
 ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
+ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
+# Isaac ROS version configuration
+ARG ISAAC_ROS=YES
+ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
+# Copy and run Isaac ROS installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+# Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/gazebo_world_ws/docker/compose.yaml
+++ b/gazebo_world_ws/docker/compose.yaml
@@ -5,11 +5,20 @@ services:
     image: ubuntu:22.04
     container_name: ros2-gazebo-world-ws-volume-instantiation
     command: bash -c "
+        echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
         mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+        "
     volumes:
       - isaac-sim-cache:/isaac-sim
   gazebo-world-ws:

--- a/gazebo_world_ws/docker/compose.yaml
+++ b/gazebo_world_ws/docker/compose.yaml
@@ -8,7 +8,8 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data}"
+        mkdir -p /isaac-sim/standalone/{logs,data} &&
+        chown -R 1000:1000 /isaac-sim"
     volumes:
       - isaac-sim-cache:/isaac-sim
   gazebo-world-ws:
@@ -24,10 +25,14 @@ services:
       args:
         # TODO: Set the USER_UID
         USER_UID: "${USER_UID:-1000}"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
         # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
       cache_from:
         - j3soon/ros2-gazebo-world-ws:buildcache-amd64
         - j3soon/ros2-gazebo-world-ws:buildcache-arm64

--- a/h1_ws/docker/.bashrc
+++ b/h1_ws/docker/.bashrc
@@ -7,25 +7,7 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
-# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
-echo "changing ownership of Isaac Sim user cache directories..."
-sudo chown user:user /isaac-sim
-sudo chown user:user /isaac-sim/kit
-sudo chown user:user /isaac-sim/kit/cache
-sudo chown user:user /home/user/.cache
-sudo chown user:user /home/user/.cache/ov
-sudo chown user:user /home/user/.cache/pip
-sudo chown user:user /home/user/.cache/nvidia
-sudo chown user:user /home/user/.cache/nvidia/GLCache
-sudo chown user:user /home/user/.nv
-sudo chown user:user /home/user/.nv/ComputeCache
-sudo chown user:user /home/user/.nvidia-omniverse
-sudo chown user:user /home/user/.nvidia-omniverse/logs
-sudo chown user:user /home/user/.local/share/ov
-sudo chown user:user /home/user/.local/share/ov/data
-sudo chown user:user /home/user/Documents
-# Set the CycloneDDS configuration file
-export CYCLONEDDS_URI=/home/user/cyclonedds.xml
+
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/h1_ws/docker/Dockerfile
+++ b/h1_ws/docker/Dockerfile
@@ -27,10 +27,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get update && apt-get install -y \
     curl \
     git \
+    git-lfs \
     htop \
     iputils-ping \
+    jq \
     nano \
     net-tools \
+    netcat-traditional \
+    nmap \
     tmux \
     tree \
     unzip \
@@ -52,6 +56,8 @@ ENV ROS_DISTRO=$ROS_DISTRO
 COPY modules/install_ros.sh /tmp/install_ros.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_ros.sh && rm /tmp/install_ros.sh
+# Set the CycloneDDS configuration file
+ENV CYCLONEDDS_URI=/home/user/cyclonedds.xml
 
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
@@ -62,6 +68,16 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 COPY modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
+
+# Install CUDA Toolkit (not installed by default)
+ARG CUDA_TOOLKIT_VERSION=""
+# Copy and run CUDA Toolkit installation script
+COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
+# Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#post-installation-actions
+ENV PATH="${PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/lib64"
 
 # Arguments for the default user
 ARG USERNAME=user
@@ -77,34 +93,52 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 
 USER $USERNAME
 
+# Create cache directories with correct ownership to avoid permission issues after volume mount
+RUN mkdir -p /home/$USERNAME/.cache/pip
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53
 ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
+ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
+# Isaac ROS version configuration
+ARG ISAAC_ROS=YES
+ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
+# Copy and run Isaac ROS installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+# Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/h1_ws/docker/compose.yaml
+++ b/h1_ws/docker/compose.yaml
@@ -8,7 +8,8 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data}"
+        mkdir -p /isaac-sim/standalone/{logs,data} &&
+        chown -R 1000:1000 /isaac-sim"
     volumes:
       - isaac-sim-cache:/isaac-sim
   h1-ws:
@@ -24,10 +25,14 @@ services:
       args:
         # TODO: Set the USER_UID
         USER_UID: "${USER_UID:-1000}"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
         # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
       cache_from:
         - j3soon/ros2-h1-ws:buildcache-amd64
         - j3soon/ros2-h1-ws:buildcache-arm64

--- a/h1_ws/docker/compose.yaml
+++ b/h1_ws/docker/compose.yaml
@@ -5,11 +5,20 @@ services:
     image: ubuntu:22.04
     container_name: ros2-h1-ws-volume-instantiation
     command: bash -c "
+        echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
         mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+        "
     volumes:
       - isaac-sim-cache:/isaac-sim
   h1-ws:

--- a/husky_ws/docker/.bashrc
+++ b/husky_ws/docker/.bashrc
@@ -7,25 +7,7 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
-# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
-echo "changing ownership of Isaac Sim user cache directories..."
-sudo chown user:user /isaac-sim
-sudo chown user:user /isaac-sim/kit
-sudo chown user:user /isaac-sim/kit/cache
-sudo chown user:user /home/user/.cache
-sudo chown user:user /home/user/.cache/ov
-sudo chown user:user /home/user/.cache/pip
-sudo chown user:user /home/user/.cache/nvidia
-sudo chown user:user /home/user/.cache/nvidia/GLCache
-sudo chown user:user /home/user/.nv
-sudo chown user:user /home/user/.nv/ComputeCache
-sudo chown user:user /home/user/.nvidia-omniverse
-sudo chown user:user /home/user/.nvidia-omniverse/logs
-sudo chown user:user /home/user/.local/share/ov
-sudo chown user:user /home/user/.local/share/ov/data
-sudo chown user:user /home/user/Documents
-# Set the CycloneDDS configuration file
-export CYCLONEDDS_URI=/home/user/cyclonedds.xml
+
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/husky_ws/docker/Dockerfile
+++ b/husky_ws/docker/Dockerfile
@@ -27,10 +27,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get update && apt-get install -y \
     curl \
     git \
+    git-lfs \
     htop \
     iputils-ping \
+    jq \
     nano \
     net-tools \
+    netcat-traditional \
+    nmap \
     tmux \
     tree \
     unzip \
@@ -52,6 +56,8 @@ ENV ROS_DISTRO=$ROS_DISTRO
 COPY modules/install_ros.sh /tmp/install_ros.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_ros.sh && rm /tmp/install_ros.sh
+# Set the CycloneDDS configuration file
+ENV CYCLONEDDS_URI=/home/user/cyclonedds.xml
 
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
@@ -62,6 +68,16 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 COPY modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
+
+# Install CUDA Toolkit (not installed by default)
+ARG CUDA_TOOLKIT_VERSION=""
+# Copy and run CUDA Toolkit installation script
+COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
+# Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#post-installation-actions
+ENV PATH="${PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/lib64"
 
 # Arguments for the default user
 ARG USERNAME=user
@@ -77,34 +93,52 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 
 USER $USERNAME
 
+# Create cache directories with correct ownership to avoid permission issues after volume mount
+RUN mkdir -p /home/$USERNAME/.cache/pip
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53
 ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
+ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
+# Isaac ROS version configuration
+ARG ISAAC_ROS=YES
+ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
+# Copy and run Isaac ROS installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+# Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/husky_ws/docker/compose.yaml
+++ b/husky_ws/docker/compose.yaml
@@ -8,7 +8,8 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data}"
+        mkdir -p /isaac-sim/standalone/{logs,data} &&
+        chown -R 1000:1000 /isaac-sim"
     volumes:
       - isaac-sim-cache:/isaac-sim
   husky-ws:
@@ -24,10 +25,14 @@ services:
       args:
         # TODO: Set the USER_UID
         USER_UID: "${USER_UID:-1000}"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
         # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
       cache_from:
         - j3soon/ros2-husky-ws:buildcache-amd64
         - j3soon/ros2-husky-ws:buildcache-arm64

--- a/husky_ws/docker/compose.yaml
+++ b/husky_ws/docker/compose.yaml
@@ -5,11 +5,20 @@ services:
     image: ubuntu:22.04
     container_name: ros2-husky-ws-volume-instantiation
     command: bash -c "
+        echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
         mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+        "
     volumes:
       - isaac-sim-cache:/isaac-sim
   husky-ws:

--- a/kobuki_ws/docker/.bashrc
+++ b/kobuki_ws/docker/.bashrc
@@ -7,25 +7,7 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
-# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
-echo "changing ownership of Isaac Sim user cache directories..."
-sudo chown user:user /isaac-sim
-sudo chown user:user /isaac-sim/kit
-sudo chown user:user /isaac-sim/kit/cache
-sudo chown user:user /home/user/.cache
-sudo chown user:user /home/user/.cache/ov
-sudo chown user:user /home/user/.cache/pip
-sudo chown user:user /home/user/.cache/nvidia
-sudo chown user:user /home/user/.cache/nvidia/GLCache
-sudo chown user:user /home/user/.nv
-sudo chown user:user /home/user/.nv/ComputeCache
-sudo chown user:user /home/user/.nvidia-omniverse
-sudo chown user:user /home/user/.nvidia-omniverse/logs
-sudo chown user:user /home/user/.local/share/ov
-sudo chown user:user /home/user/.local/share/ov/data
-sudo chown user:user /home/user/Documents
-# Set the CycloneDDS configuration file
-export CYCLONEDDS_URI=/home/user/cyclonedds.xml
+
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/kobuki_ws/docker/Dockerfile
+++ b/kobuki_ws/docker/Dockerfile
@@ -27,10 +27,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get update && apt-get install -y \
     curl \
     git \
+    git-lfs \
     htop \
     iputils-ping \
+    jq \
     nano \
     net-tools \
+    netcat-traditional \
+    nmap \
     tmux \
     tree \
     unzip \
@@ -52,6 +56,8 @@ ENV ROS_DISTRO=$ROS_DISTRO
 COPY modules/install_ros.sh /tmp/install_ros.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_ros.sh && rm /tmp/install_ros.sh
+# Set the CycloneDDS configuration file
+ENV CYCLONEDDS_URI=/home/user/cyclonedds.xml
 
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
@@ -62,6 +68,16 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 COPY modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
+
+# Install CUDA Toolkit (not installed by default)
+ARG CUDA_TOOLKIT_VERSION=""
+# Copy and run CUDA Toolkit installation script
+COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
+# Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#post-installation-actions
+ENV PATH="${PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/lib64"
 
 # Arguments for the default user
 ARG USERNAME=user
@@ -77,34 +93,52 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 
 USER $USERNAME
 
+# Create cache directories with correct ownership to avoid permission issues after volume mount
+RUN mkdir -p /home/$USERNAME/.cache/pip
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53
 ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
+ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
+# Isaac ROS version configuration
+ARG ISAAC_ROS=YES
+ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
+# Copy and run Isaac ROS installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+# Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/kobuki_ws/docker/compose.yaml
+++ b/kobuki_ws/docker/compose.yaml
@@ -5,11 +5,20 @@ services:
     image: ubuntu:22.04
     container_name: ros2-kobuki-ws-volume-instantiation
     command: bash -c "
+        echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
         mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+        "
     volumes:
       - isaac-sim-cache:/isaac-sim
   kobuki-ws:

--- a/kobuki_ws/docker/compose.yaml
+++ b/kobuki_ws/docker/compose.yaml
@@ -8,7 +8,8 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data}"
+        mkdir -p /isaac-sim/standalone/{logs,data} &&
+        chown -R 1000:1000 /isaac-sim"
     volumes:
       - isaac-sim-cache:/isaac-sim
   kobuki-ws:
@@ -24,10 +25,14 @@ services:
       args:
         # TODO: Set the USER_UID
         USER_UID: "${USER_UID:-1000}"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
         # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
       cache_from:
         - j3soon/ros2-kobuki-ws:buildcache-amd64
         - j3soon/ros2-kobuki-ws:buildcache-arm64

--- a/orbslam3_ws/docker/.bashrc
+++ b/orbslam3_ws/docker/.bashrc
@@ -7,25 +7,7 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
-# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
-echo "changing ownership of Isaac Sim user cache directories..."
-sudo chown user:user /isaac-sim
-sudo chown user:user /isaac-sim/kit
-sudo chown user:user /isaac-sim/kit/cache
-sudo chown user:user /home/user/.cache
-sudo chown user:user /home/user/.cache/ov
-sudo chown user:user /home/user/.cache/pip
-sudo chown user:user /home/user/.cache/nvidia
-sudo chown user:user /home/user/.cache/nvidia/GLCache
-sudo chown user:user /home/user/.nv
-sudo chown user:user /home/user/.nv/ComputeCache
-sudo chown user:user /home/user/.nvidia-omniverse
-sudo chown user:user /home/user/.nvidia-omniverse/logs
-sudo chown user:user /home/user/.local/share/ov
-sudo chown user:user /home/user/.local/share/ov/data
-sudo chown user:user /home/user/Documents
-# Set the CycloneDDS configuration file
-export CYCLONEDDS_URI=/home/user/cyclonedds.xml
+
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/orbslam3_ws/docker/Dockerfile
+++ b/orbslam3_ws/docker/Dockerfile
@@ -27,10 +27,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get update && apt-get install -y \
     curl \
     git \
+    git-lfs \
     htop \
     iputils-ping \
+    jq \
     nano \
     net-tools \
+    netcat-traditional \
+    nmap \
     tmux \
     tree \
     unzip \
@@ -52,6 +56,8 @@ ENV ROS_DISTRO=$ROS_DISTRO
 COPY modules/install_ros.sh /tmp/install_ros.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_ros.sh && rm /tmp/install_ros.sh
+# Set the CycloneDDS configuration file
+ENV CYCLONEDDS_URI=/home/user/cyclonedds.xml
 
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
@@ -62,6 +68,16 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 COPY modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
+
+# Install CUDA Toolkit (not installed by default)
+ARG CUDA_TOOLKIT_VERSION=""
+# Copy and run CUDA Toolkit installation script
+COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
+# Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#post-installation-actions
+ENV PATH="${PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/lib64"
 
 # Arguments for the default user
 ARG USERNAME=user
@@ -77,34 +93,52 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 
 USER $USERNAME
 
+# Create cache directories with correct ownership to avoid permission issues after volume mount
+RUN mkdir -p /home/$USERNAME/.cache/pip
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53
 ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
+ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
+# Isaac ROS version configuration
+ARG ISAAC_ROS=YES
+ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
+# Copy and run Isaac ROS installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+# Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/orbslam3_ws/docker/compose.yaml
+++ b/orbslam3_ws/docker/compose.yaml
@@ -8,7 +8,8 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data}"
+        mkdir -p /isaac-sim/standalone/{logs,data} &&
+        chown -R 1000:1000 /isaac-sim"
     volumes:
       - isaac-sim-cache:/isaac-sim
   orbslam3-ws:
@@ -24,10 +25,14 @@ services:
       args:
         # TODO: Set the USER_UID
         USER_UID: "${USER_UID:-1000}"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
         # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
       cache_from:
         - j3soon/ros2-orbslam3-ws:buildcache-amd64
         - j3soon/ros2-orbslam3-ws:buildcache-arm64

--- a/orbslam3_ws/docker/compose.yaml
+++ b/orbslam3_ws/docker/compose.yaml
@@ -5,11 +5,20 @@ services:
     image: ubuntu:22.04
     container_name: ros2-orbslam3-ws-volume-instantiation
     command: bash -c "
+        echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
         mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+        "
     volumes:
       - isaac-sim-cache:/isaac-sim
   orbslam3-ws:

--- a/rtabmap_ws/docker/.bashrc
+++ b/rtabmap_ws/docker/.bashrc
@@ -7,25 +7,7 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
-# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
-echo "changing ownership of Isaac Sim user cache directories..."
-sudo chown user:user /isaac-sim
-sudo chown user:user /isaac-sim/kit
-sudo chown user:user /isaac-sim/kit/cache
-sudo chown user:user /home/user/.cache
-sudo chown user:user /home/user/.cache/ov
-sudo chown user:user /home/user/.cache/pip
-sudo chown user:user /home/user/.cache/nvidia
-sudo chown user:user /home/user/.cache/nvidia/GLCache
-sudo chown user:user /home/user/.nv
-sudo chown user:user /home/user/.nv/ComputeCache
-sudo chown user:user /home/user/.nvidia-omniverse
-sudo chown user:user /home/user/.nvidia-omniverse/logs
-sudo chown user:user /home/user/.local/share/ov
-sudo chown user:user /home/user/.local/share/ov/data
-sudo chown user:user /home/user/Documents
-# Set the CycloneDDS configuration file
-export CYCLONEDDS_URI=/home/user/cyclonedds.xml
+
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/rtabmap_ws/docker/Dockerfile
+++ b/rtabmap_ws/docker/Dockerfile
@@ -32,10 +32,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get update && apt-get install -y \
     curl \
     git \
+    git-lfs \
     htop \
     iputils-ping \
+    jq \
     nano \
     net-tools \
+    netcat-traditional \
+    nmap \
     tmux \
     tree \
     unzip \
@@ -89,34 +93,52 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 
 USER $USERNAME
 
+# Create cache directories with correct ownership to avoid permission issues after volume mount
+RUN mkdir -p /home/$USERNAME/.cache/pip
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53
 ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
+ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
+# Isaac ROS version configuration
+ARG ISAAC_ROS=YES
+ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
+# Copy and run Isaac ROS installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+# Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/rtabmap_ws/docker/compose.yaml
+++ b/rtabmap_ws/docker/compose.yaml
@@ -8,7 +8,8 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data}"
+        mkdir -p /isaac-sim/standalone/{logs,data} &&
+        chown -R 1000:1000 /isaac-sim"
     volumes:
       - isaac-sim-cache:/isaac-sim
   rtabmap-ws:
@@ -24,10 +25,14 @@ services:
       args:
         # TODO: Set the USER_UID
         USER_UID: "${USER_UID:-1000}"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
         # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
       cache_from:
         - j3soon/ros2-rtabmap-ws:buildcache-amd64
         - j3soon/ros2-rtabmap-ws:buildcache-arm64

--- a/rtabmap_ws/docker/compose.yaml
+++ b/rtabmap_ws/docker/compose.yaml
@@ -5,11 +5,20 @@ services:
     image: ubuntu:22.04
     container_name: ros2-rtabmap-ws-volume-instantiation
     command: bash -c "
+        echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
         mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+        "
     volumes:
       - isaac-sim-cache:/isaac-sim
   rtabmap-ws:

--- a/scripts/setup_docker_modules_link.sh
+++ b/scripts/setup_docker_modules_link.sh
@@ -12,7 +12,16 @@ workspaces=( *_ws* )
 for ws in "${workspaces[@]}"
 do
     mkdir -p "${ws}/docker/modules"
-    rm -f "${ws}/docker/modules"/* 2>/dev/null || true
+    for file in "${ws}/docker/modules"/*; do
+        # Check if the file is a hard link
+        # Ref: https://unix.stackexchange.com/a/167616
+        if [ "$(stat -c %h -- "$file")" -gt 1 ]; then
+            rm "$file" 2>/dev/null
+        else
+            echo "Error: Found regular file instead of symlink: $file"
+            exit 1
+        fi
+    done
     for file in docker_modules/*; do
         if [ -f "$file" ]; then
             ln "$file" "${ws}/docker/modules/"

--- a/template_ws/docker/.bashrc
+++ b/template_ws/docker/.bashrc
@@ -7,23 +7,6 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
-# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
-echo "changing ownership of Isaac Sim user cache directories..."
-sudo chown user:user /isaac-sim
-sudo chown user:user /isaac-sim/kit
-sudo chown user:user /isaac-sim/kit/cache
-sudo chown user:user /home/user/.cache
-sudo chown user:user /home/user/.cache/ov
-sudo chown user:user /home/user/.cache/pip
-sudo chown user:user /home/user/.cache/nvidia
-sudo chown user:user /home/user/.cache/nvidia/GLCache
-sudo chown user:user /home/user/.nv
-sudo chown user:user /home/user/.nv/ComputeCache
-sudo chown user:user /home/user/.nvidia-omniverse
-sudo chown user:user /home/user/.nvidia-omniverse/logs
-sudo chown user:user /home/user/.local/share/ov
-sudo chown user:user /home/user/.local/share/ov/data
-sudo chown user:user /home/user/Documents
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/template_ws/docker/.bashrc
+++ b/template_ws/docker/.bashrc
@@ -7,6 +7,7 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/template_ws/docker/.bashrc
+++ b/template_ws/docker/.bashrc
@@ -24,8 +24,6 @@ sudo chown user:user /home/user/.nvidia-omniverse/logs
 sudo chown user:user /home/user/.local/share/ov
 sudo chown user:user /home/user/.local/share/ov/data
 sudo chown user:user /home/user/Documents
-# Set the CycloneDDS configuration file
-export CYCLONEDDS_URI=/home/user/cyclonedds.xml
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -105,6 +105,20 @@ ENV OMNI_KIT_ACCEPT_EULA=YES
 # Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
 ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
+# Create Isaac Sim directories with correct ownership to avoid permission issues after volume mount
+RUN sudo mkdir -p /isaac-sim && sudo chown $USERNAME:$USERNAME /isaac-sim
+RUN mkdir -p /isaac-sim/kit/cache \
+    && mkdir -p /home/$USERNAME/.cache/ov \
+    && mkdir -p /home/$USERNAME/.local/lib/python3.10/site-packages/omni/cache \
+    && mkdir -p /home/$USERNAME/.cache/pip \
+    && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
+    && mkdir -p /home/$USERNAME/.nv/ComputeCache \
+    && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
+    && mkdir -p /home/$USERNAME/.local/lib/python3.10/site-packages/omni/logs \
+    && mkdir -p /home/$USERNAME/.local/share/ov/data \
+    && mkdir -p /home/$USERNAME/.local/lib/python3.10/site-packages/omni/data \
+    && mkdir -p /home/$USERNAME/Documents
+
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color

--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -89,7 +89,7 @@ RUN mkdir /home/$USERNAME/.gazebo
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
 # Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
-ENV ISAACSIM_PATH="${HOME}/isaacsim"
+ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
@@ -111,12 +111,22 @@ ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
 # Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
-ENV ISAACLAB_PATH="${HOME}/IsaacLab"
+ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
     ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
+# Isaac ROS version configuration
+ARG ISAAC_ROS=YES
+ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
+# Copy and run Isaac ROS installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    ISAAC_ROS=$ISAAC_ROS /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+# Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -27,10 +27,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get update && apt-get install -y \
     curl \
     git \
+    git-lfs \
     htop \
     iputils-ping \
+    jq \
     nano \
     net-tools \
+    netcat-traditional \
+    nmap \
     tmux \
     tree \
     unzip \

--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -88,6 +88,8 @@ RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PATH="${HOME}/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
@@ -100,12 +102,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
+ENV ISAACLAB_PATH="${HOME}/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -74,7 +74,7 @@ ARG CUDA_TOOLKIT_VERSION=12.6
 # Copy and run CUDA Toolkit installation script
 COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    CUDA_TOOLKIT_VERSION=$CUDA_TOOLKIT_VERSION /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
+    /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
 # Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#post-installation-actions
 ENV PATH="${PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/bin"
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/lib64"
@@ -93,6 +93,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 
 USER $USERNAME
 
+# Create cache directories with correct ownership to avoid permission issues after volume mount
+RUN mkdir -p /home/$USERNAME/.cache/pip
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
@@ -104,8 +106,8 @@ ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53
@@ -125,8 +127,8 @@ ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
 
 # Isaac ROS version configuration
 ARG ISAAC_ROS=YES
@@ -135,7 +137,7 @@ ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    ISAAC_ROS=$ISAAC_ROS /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+    /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
 # Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools

--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -69,6 +69,16 @@ COPY modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
+# Install CUDA Toolkit
+ARG CUDA_TOOLKIT_VERSION=12.6
+# Copy and run CUDA Toolkit installation script
+COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    CUDA_TOOLKIT_VERSION=$CUDA_TOOLKIT_VERSION /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
+# Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#post-installation-actions
+ENV PATH="${PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/lib64"
+
 # Arguments for the default user
 ARG USERNAME=user
 ARG USER_UID=1000

--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -69,8 +69,8 @@ COPY modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
 
-# Install CUDA Toolkit
-ARG CUDA_TOOLKIT_VERSION=12.6
+# Install CUDA Toolkit (not installed by default)
+ARG CUDA_TOOLKIT_VERSION=""
 # Copy and run CUDA Toolkit installation script
 COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -105,20 +105,6 @@ ENV OMNI_KIT_ACCEPT_EULA=YES
 # Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
 ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
-# Create Isaac Sim directories with correct ownership to avoid permission issues after volume mount
-RUN sudo mkdir -p /isaac-sim && sudo chown $USERNAME:$USERNAME /isaac-sim
-RUN mkdir -p /isaac-sim/kit/cache \
-    && mkdir -p /home/$USERNAME/.cache/ov \
-    && mkdir -p /home/$USERNAME/.local/lib/python3.10/site-packages/omni/cache \
-    && mkdir -p /home/$USERNAME/.cache/pip \
-    && mkdir -p /home/$USERNAME/.cache/nvidia/GLCache \
-    && mkdir -p /home/$USERNAME/.nv/ComputeCache \
-    && mkdir -p /home/$USERNAME/.nvidia-omniverse/logs \
-    && mkdir -p /home/$USERNAME/.local/lib/python3.10/site-packages/omni/logs \
-    && mkdir -p /home/$USERNAME/.local/share/ov/data \
-    && mkdir -p /home/$USERNAME/.local/lib/python3.10/site-packages/omni/data \
-    && mkdir -p /home/$USERNAME/Documents
-
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color

--- a/template_ws/docker/Dockerfile
+++ b/template_ws/docker/Dockerfile
@@ -56,6 +56,8 @@ ENV ROS_DISTRO=$ROS_DISTRO
 COPY modules/install_ros.sh /tmp/install_ros.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_ros.sh && rm /tmp/install_ros.sh
+# Set the CycloneDDS configuration file
+ENV CYCLONEDDS_URI=/home/user/cyclonedds.xml
 
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities

--- a/template_ws/docker/compose.yaml
+++ b/template_ws/docker/compose.yaml
@@ -30,6 +30,8 @@ services:
         # ISAAC_LAB_VERSION: "2.1.0"
         # TODO: Set Isaac ROS to "" if not using Isaac ROS
         # ISAAC_ROS: "YES"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: "12.6"
       cache_from:
         - j3soon/ros2-template-ws:buildcache-amd64
         - j3soon/ros2-template-ws:buildcache-arm64

--- a/template_ws/docker/compose.yaml
+++ b/template_ws/docker/compose.yaml
@@ -28,6 +28,8 @@ services:
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
       cache_from:
         - j3soon/ros2-template-ws:buildcache-amd64
         - j3soon/ros2-template-ws:buildcache-arm64

--- a/template_ws/docker/compose.yaml
+++ b/template_ws/docker/compose.yaml
@@ -5,11 +5,20 @@ services:
     image: ubuntu:22.04
     container_name: ros2-template-ws-volume-instantiation
     command: bash -c "
+        echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
         mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+        "
     volumes:
       - isaac-sim-cache:/isaac-sim
   template-ws:

--- a/template_ws/docker/compose.yaml
+++ b/template_ws/docker/compose.yaml
@@ -25,14 +25,14 @@ services:
       args:
         # TODO: Set the USER_UID
         USER_UID: "${USER_UID:-1000}"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
         # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
         # TODO: Set Isaac ROS to "" if not using Isaac ROS
         # ISAAC_ROS: "YES"
-        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
-        # CUDA_TOOLKIT_VERSION: "12.6"
       cache_from:
         - j3soon/ros2-template-ws:buildcache-amd64
         - j3soon/ros2-template-ws:buildcache-arm64

--- a/template_ws/docker/compose.yaml
+++ b/template_ws/docker/compose.yaml
@@ -8,7 +8,8 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data}"
+        mkdir -p /isaac-sim/standalone/{logs,data} &&
+        chown -R 1000:1000 /isaac-sim"
     volumes:
       - isaac-sim-cache:/isaac-sim
   template-ws:

--- a/tests/diff_base/docker/.bashrc
+++ b/tests/diff_base/docker/.bashrc
@@ -8,25 +8,7 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
-# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
-echo "changing ownership of Isaac Sim user cache directories..."
-sudo chown user:user /isaac-sim
-sudo chown user:user /isaac-sim/kit
-sudo chown user:user /isaac-sim/kit/cache
-sudo chown user:user /home/user/.cache
-sudo chown user:user /home/user/.cache/ov
-sudo chown user:user /home/user/.cache/pip
-sudo chown user:user /home/user/.cache/nvidia
-sudo chown user:user /home/user/.cache/nvidia/GLCache
-sudo chown user:user /home/user/.nv
-sudo chown user:user /home/user/.nv/ComputeCache
-sudo chown user:user /home/user/.nvidia-omniverse
-sudo chown user:user /home/user/.nvidia-omniverse/logs
-sudo chown user:user /home/user/.local/share/ov
-sudo chown user:user /home/user/.local/share/ov/data
-sudo chown user:user /home/user/Documents
-# Set the CycloneDDS configuration file
-export CYCLONEDDS_URI=/home/user/cyclonedds.xml
+
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/tests/diff_base/docker/Dockerfile
+++ b/tests/diff_base/docker/Dockerfile
@@ -27,10 +27,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get update && apt-get install -y \
     curl \
     git \
+    git-lfs \
     htop \
     iputils-ping \
+    jq \
     nano \
     net-tools \
+    netcat-traditional \
+    nmap \
     tmux \
     tree \
     unzip \
@@ -52,6 +56,8 @@ ENV ROS_DISTRO=$ROS_DISTRO
 COPY modules/install_ros.sh /tmp/install_ros.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_ros.sh && rm /tmp/install_ros.sh
+# Set the CycloneDDS configuration file
+ENV CYCLONEDDS_URI=/home/user/cyclonedds.xml
 
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
@@ -62,6 +68,16 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 COPY modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
+
+# Install CUDA Toolkit (not installed by default)
+ARG CUDA_TOOLKIT_VERSION=""
+# Copy and run CUDA Toolkit installation script
+COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
+# Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#post-installation-actions
+ENV PATH="${PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/lib64"
 
 # Arguments for the default user
 ARG USERNAME=user
@@ -77,34 +93,52 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 
 USER $USERNAME
 
+# Create cache directories with correct ownership to avoid permission issues after volume mount
+RUN mkdir -p /home/$USERNAME/.cache/pip
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53
 ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
+ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
+# Isaac ROS version configuration
+ARG ISAAC_ROS=YES
+ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
+# Copy and run Isaac ROS installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+# Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/tests/diff_base/docker/compose.yaml
+++ b/tests/diff_base/docker/compose.yaml
@@ -8,7 +8,8 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data}"
+        mkdir -p /isaac-sim/standalone/{logs,data} &&
+        chown -R 1000:1000 /isaac-sim"
     volumes:
       - isaac-sim-cache:/isaac-sim
   {PLACEHOLDER}-ws:
@@ -24,10 +25,14 @@ services:
       args:
         # TODO: Set the USER_UID
         USER_UID: "${USER_UID:-1000}"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
         # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
       cache_from:
         - j3soon/ros2-{PLACEHOLDER}-ws:buildcache-amd64
         - j3soon/ros2-{PLACEHOLDER}-ws:buildcache-arm64

--- a/tests/diff_base/docker/compose.yaml
+++ b/tests/diff_base/docker/compose.yaml
@@ -5,11 +5,20 @@ services:
     image: ubuntu:22.04
     container_name: ros2-{PLACEHOLDER}-volume-instantiation
     command: bash -c "
+        echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
         mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+        "
     volumes:
       - isaac-sim-cache:/isaac-sim
   {PLACEHOLDER}-ws:

--- a/tests/lint_dockerfile.py
+++ b/tests/lint_dockerfile.py
@@ -29,5 +29,9 @@ for filename in glob.glob(f"{repo_dir}/*_ws/docker/Dockerfile*"):
         raise ValueError(f"`RUN apt-get install` should not exist, use with `apt-get update` instead: '{filename}'")
     if "    apt-get install" in content:
         raise ValueError(f"`    apt-get install` should not exist, use with `apt-get update` in the same line instead: '{filename}'")
+    if "${HOME}" in content:
+        raise ValueError(f"`${{HOME}}` should not exist, use environment variables instead: '{filename}'")
+    if "$HOME" in content:
+        raise ValueError(f"`$HOME` should not exist, use environment variables instead: '{filename}'")
     if "PLACEHOLDER" in content:
         raise ValueError(f"`PLACEHOLDER` should not exist: '{filename}'")

--- a/turtlebot3_ws/docker/.bashrc
+++ b/turtlebot3_ws/docker/.bashrc
@@ -7,25 +7,7 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
-# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
-echo "changing ownership of Isaac Sim user cache directories..."
-sudo chown user:user /isaac-sim
-sudo chown user:user /isaac-sim/kit
-sudo chown user:user /isaac-sim/kit/cache
-sudo chown user:user /home/user/.cache
-sudo chown user:user /home/user/.cache/ov
-sudo chown user:user /home/user/.cache/pip
-sudo chown user:user /home/user/.cache/nvidia
-sudo chown user:user /home/user/.cache/nvidia/GLCache
-sudo chown user:user /home/user/.nv
-sudo chown user:user /home/user/.nv/ComputeCache
-sudo chown user:user /home/user/.nvidia-omniverse
-sudo chown user:user /home/user/.nvidia-omniverse/logs
-sudo chown user:user /home/user/.local/share/ov
-sudo chown user:user /home/user/.local/share/ov/data
-sudo chown user:user /home/user/Documents
-# Set the CycloneDDS configuration file
-export CYCLONEDDS_URI=/home/user/cyclonedds.xml
+
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/turtlebot3_ws/docker/Dockerfile
+++ b/turtlebot3_ws/docker/Dockerfile
@@ -27,10 +27,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get update && apt-get install -y \
     curl \
     git \
+    git-lfs \
     htop \
     iputils-ping \
+    jq \
     nano \
     net-tools \
+    netcat-traditional \
+    nmap \
     tmux \
     tree \
     unzip \
@@ -52,6 +56,8 @@ ENV ROS_DISTRO=$ROS_DISTRO
 COPY modules/install_ros.sh /tmp/install_ros.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_ros.sh && rm /tmp/install_ros.sh
+# Set the CycloneDDS configuration file
+ENV CYCLONEDDS_URI=/home/user/cyclonedds.xml
 
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
@@ -62,6 +68,16 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 COPY modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
+
+# Install CUDA Toolkit (not installed by default)
+ARG CUDA_TOOLKIT_VERSION=""
+# Copy and run CUDA Toolkit installation script
+COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
+# Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#post-installation-actions
+ENV PATH="${PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/lib64"
 
 # Arguments for the default user
 ARG USERNAME=user
@@ -77,34 +93,52 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 
 USER $USERNAME
 
+# Create cache directories with correct ownership to avoid permission issues after volume mount
+RUN mkdir -p /home/$USERNAME/.cache/pip
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53
 ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
+ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
+# Isaac ROS version configuration
+ARG ISAAC_ROS=YES
+ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
+# Copy and run Isaac ROS installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+# Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/turtlebot3_ws/docker/compose.yaml
+++ b/turtlebot3_ws/docker/compose.yaml
@@ -8,7 +8,8 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data}"
+        mkdir -p /isaac-sim/standalone/{logs,data} &&
+        chown -R 1000:1000 /isaac-sim"
     volumes:
       - isaac-sim-cache:/isaac-sim
   turtlebot3-ws:
@@ -24,10 +25,14 @@ services:
       args:
         # TODO: Set the USER_UID
         USER_UID: "${USER_UID:-1000}"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
         # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
       cache_from:
         - j3soon/ros2-turtlebot3-ws:buildcache-amd64
         - j3soon/ros2-turtlebot3-ws:buildcache-arm64

--- a/turtlebot3_ws/docker/compose.yaml
+++ b/turtlebot3_ws/docker/compose.yaml
@@ -5,11 +5,20 @@ services:
     image: ubuntu:22.04
     container_name: ros2-turtlebot3-ws-volume-instantiation
     command: bash -c "
+        echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
         mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+        "
     volumes:
       - isaac-sim-cache:/isaac-sim
   turtlebot3-ws:

--- a/vlp_ws/docker/.bashrc
+++ b/vlp_ws/docker/.bashrc
@@ -7,25 +7,7 @@ fi
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
-# Change ownership of Isaac Sim user cache directories to avoid permission issues after volume mount
-echo "changing ownership of Isaac Sim user cache directories..."
-sudo chown user:user /isaac-sim
-sudo chown user:user /isaac-sim/kit
-sudo chown user:user /isaac-sim/kit/cache
-sudo chown user:user /home/user/.cache
-sudo chown user:user /home/user/.cache/ov
-sudo chown user:user /home/user/.cache/pip
-sudo chown user:user /home/user/.cache/nvidia
-sudo chown user:user /home/user/.cache/nvidia/GLCache
-sudo chown user:user /home/user/.nv
-sudo chown user:user /home/user/.nv/ComputeCache
-sudo chown user:user /home/user/.nvidia-omniverse
-sudo chown user:user /home/user/.nvidia-omniverse/logs
-sudo chown user:user /home/user/.local/share/ov
-sudo chown user:user /home/user/.local/share/ov/data
-sudo chown user:user /home/user/Documents
-# Set the CycloneDDS configuration file
-export CYCLONEDDS_URI=/home/user/cyclonedds.xml
+
 # Source global ROS2 environment
 source /opt/ros/$ROS_DISTRO/setup.bash
 # Optionally perform apt update if it has not been executed yet

--- a/vlp_ws/docker/Dockerfile
+++ b/vlp_ws/docker/Dockerfile
@@ -27,10 +27,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get update && apt-get install -y \
     curl \
     git \
+    git-lfs \
     htop \
     iputils-ping \
+    jq \
     nano \
     net-tools \
+    netcat-traditional \
+    nmap \
     tmux \
     tree \
     unzip \
@@ -52,6 +56,8 @@ ENV ROS_DISTRO=$ROS_DISTRO
 COPY modules/install_ros.sh /tmp/install_ros.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_ros.sh && rm /tmp/install_ros.sh
+# Set the CycloneDDS configuration file
+ENV CYCLONEDDS_URI=/home/user/cyclonedds.xml
 
 # Setup the required capabilities for the container runtime
 # Ref: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities
@@ -62,6 +68,16 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 COPY modules/install_x11_opengl_vulkan.sh /tmp/install_x11_opengl_vulkan.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
     /tmp/install_x11_opengl_vulkan.sh && rm /tmp/install_x11_opengl_vulkan.sh
+
+# Install CUDA Toolkit (not installed by default)
+ARG CUDA_TOOLKIT_VERSION=""
+# Copy and run CUDA Toolkit installation script
+COPY modules/install_cuda_toolkit.sh /tmp/install_cuda_toolkit.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_cuda_toolkit.sh && rm /tmp/install_cuda_toolkit.sh
+# Ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#post-installation-actions
+ENV PATH="${PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-${CUDA_TOOLKIT_VERSION}/lib64"
 
 # Arguments for the default user
 ARG USERNAME=user
@@ -77,34 +93,52 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 
 USER $USERNAME
 
+# Create cache directories with correct ownership to avoid permission issues after volume mount
+RUN mkdir -p /home/$USERNAME/.cache/pip
 # Create Gazebo cache directory with correct ownership to avoid permission issues after volume mount
 RUN mkdir /home/$USERNAME/.gazebo
 
 # Isaac Sim version configuration
 ARG ISAAC_SIM_VERSION=4.5.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PATH="/home/$USERNAME/isaacsim"
 # Copy and run Isaac Sim installation script
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_sim.sh /tmp/install_isaac_sim.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_SIM_VERSION=$ISAAC_SIM_VERSION /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_sim.sh && rm /tmp/install_isaac_sim.sh
 # Set Isaac Sim environment variables
 # Ref: https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_python.html#running-isaac-sim
 # Ref: https://github.com/NVIDIA-Omniverse/IsaacSim-dockerfiles/blob/e3c09375c2d110b39c3fab3611352870aa3ce6ee/Dockerfile.2023.1.0-ubuntu22.04#L49-L53
 ENV OMNI_USER=admin
 ENV OMNI_PASS=admin
 ENV OMNI_KIT_ACCEPT_EULA=YES
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/setup/installation/binaries_installation.html
+ENV ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
 # Set TERM to prevent Isaac Lab error during docker build:
 #    'ansi+tabs': unknown terminal type.
 ENV TERM=xterm-256color
 # Isaac Lab version configuration
 ARG ISAAC_LAB_VERSION=2.1.0
+# Ref: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/policy_deployment/00_hover/hover_policy.html
+ENV ISAACLAB_PATH="/home/$USERNAME/IsaacLab"
 COPY --chown=$USERNAME:$USERNAME \
      modules/install_isaac_lab.sh /tmp/install_isaac_lab.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private \
-    ISAAC_LAB_VERSION=$ISAAC_LAB_VERSION /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+    --mount=type=cache,target=/home/$USERNAME/.cache/pip,sharing=private,uid=$USER_UID,gid=$USER_UID \
+    /tmp/install_isaac_lab.sh && rm /tmp/install_isaac_lab.sh
+
+# Isaac ROS version configuration
+ARG ISAAC_ROS=YES
+ENV ISAAC_ROS_WS="/home/$USERNAME/workspaces/isaac_ros-dev/"
+# Copy and run Isaac ROS installation script
+COPY --chown=$USERNAME:$USERNAME \
+     modules/install_isaac_ros.sh /tmp/install_isaac_ros.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+    /tmp/install_isaac_ros.sh && rm /tmp/install_isaac_ros.sh
+# Ref: https://nvidia-isaac-ros.github.io/getting_started/dev_env_setup.html
 
 # Install custom tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \

--- a/vlp_ws/docker/compose.yaml
+++ b/vlp_ws/docker/compose.yaml
@@ -5,11 +5,20 @@ services:
     image: ubuntu:22.04
     container_name: ros2-vlp-ws-volume-instantiation
     command: bash -c "
+        echo 'Creating directories and setting ownership for UID ${USER_UID:-1000}...' &&
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
         mkdir -p /isaac-sim/standalone/{logs,data} &&
-        chown -R 1000:1000 /isaac-sim"
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/{logs,data,documents} &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/cache/ov &&
+        chown ${USER_UID:-1000}:${USER_UID:-1000} /isaac-sim/standalone/{logs,data}
+        "
     volumes:
       - isaac-sim-cache:/isaac-sim
   vlp-ws:

--- a/vlp_ws/docker/compose.yaml
+++ b/vlp_ws/docker/compose.yaml
@@ -8,7 +8,8 @@ services:
         mkdir -p /isaac-sim/cache/{kit,ov,pip,glcache,computecache} &&
         mkdir -p /isaac-sim/{logs,data,documents} &&
         mkdir -p /isaac-sim/standalone/cache/ov &&
-        mkdir -p /isaac-sim/standalone/{logs,data}"
+        mkdir -p /isaac-sim/standalone/{logs,data} &&
+        chown -R 1000:1000 /isaac-sim"
     volumes:
       - isaac-sim-cache:/isaac-sim
   vlp-ws:
@@ -24,10 +25,14 @@ services:
       args:
         # TODO: Set the USER_UID
         USER_UID: "${USER_UID:-1000}"
+        # TODO: Set CUDA Toolkit version or set to "" if not using CUDA Toolkit
+        # CUDA_TOOLKIT_VERSION: ""
         # TODO: Set Isaac Sim version or set to "" if not using Isaac Sim
         # ISAAC_SIM_VERSION: "4.5.0"
         # TODO: Set Isaac Lab version or set to "" if not using Isaac Lab
         # ISAAC_LAB_VERSION: "2.1.0"
+        # TODO: Set Isaac ROS to "" if not using Isaac ROS
+        # ISAAC_ROS: "YES"
       cache_from:
         - j3soon/ros2-vlp-ws:buildcache-amd64
         - j3soon/ros2-vlp-ws:buildcache-arm64


### PR DESCRIPTION
No extra docker image size, as CUDA Toolkit is not installed by default and Isaac ROS base support only configures apt sources.

Other minor fixes/refactors worth mentioning:
- Keep env vars in Dockerfile instead of `.bashrc` if possible. (This decision is arbitrary for now and may be changed in the future)
- Correctly fix named volume mount permission issues

Some potential issues and notes:
- CUDA Toolkit install only supports amd64 arch for now.
  - In most python cases, this is not required, as `pip install torch` will install the correct version automatically (as mentioned in the docs). I think this will only be required if using C++.
- Isaac ROS base configuration is not enough to run any example now, as more external dependencies are required
  - Ref: https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_common/blob/main/docker/Dockerfile.base
